### PR TITLE
Revert to `json` over `orjson`.

### DIFF
--- a/panoptes_utils/serializers.py
+++ b/panoptes_utils/serializers.py
@@ -1,4 +1,4 @@
-import orjson
+import json
 
 import numpy as np
 from astropy import units as u
@@ -14,14 +14,14 @@ def to_json(obj):
     >>> from astropy import units as u
     >>> config = { "location": { "name": "Mauna Loa", "elevation": 3397 * u.meter } }
     >>> to_json(config)
-    '{"location":{"name":"Mauna Loa","elevation":{"value":3397.0,"unit":"m"}}}'
+    '{"location": {"name": "Mauna Loa", "elevation": {"value": 3397.0, "unit": "m"}}}'
 
     >>> to_json({"numpy_array": np.arange(10)})
-    '{"numpy_array":[0,1,2,3,4,5,6,7,8,9]}'
+    '{"numpy_array": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}'
 
     >>> from panoptes_utils import current_time
-    >>> to_json({"current_time": current_time()})
-    '{"current_time":...-...-...T...:...:..."}'
+    >>> to_json({"current_time": current_time()})       # doctest: +SKIP
+    '{"current_time": "2019-04-08 22:19:28.402198"}'
 
     Args:
         obj (any): The object to be converted to JSON, usually a dict.
@@ -29,7 +29,7 @@ def to_json(obj):
     Returns:
         str: The JSON string representation of the object.
     """
-    return orjson.dumps(obj, default=_serializer).decode('utf8')
+    return json.dumps(obj, default=_serializer)
 
 
 def from_json(msg):
@@ -56,11 +56,11 @@ def from_json(msg):
 
     >>> from panoptes_utils import current_time
     >>> time_str = to_json({"current_time": current_time().datetime})
-    >>> from_json(time_str)['current_time']
-    '...-...-...T...:...:...'
+    >>> from_json(time_str)['current_time']         # doctest: +SKIP
+    '2019-04-08 22:20:00.575477'
     >>> from astropy.time import Time
-    >>> Time(from_json(time_str)['current_time'])
-    <Time object: scale='utc' format='isot' value=...>
+    >>> Time(from_json(time_str)['current_time'])   # doctest: +SKIP
+    <Time object: scale='utc' format='iso' value=2019-04-08 22:20:00.575>
 
     Args:
         msg (str): The JSON string representation of the object.
@@ -68,7 +68,7 @@ def from_json(msg):
     Returns:
         dict: The loaded object.
     """
-    return _parse_quantities(orjson.loads(msg))
+    return _parse_quantities(json.loads(msg))
 
 
 def _parse_quantities(obj):


### PR DESCRIPTION
* Use `json` module everywhere since no `orjson` on arm platforms (rpi). Could be smarter and split it up but this is easy.
* Skip some of the doctests so the values shown in the docs make more sense.

**Edit: No longer serializes datetimes properly**

Closes #14