### PR TITLE
Config server convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See the full documentation at: https://panoptes-utils.readthedocs.io
 # Install
 <a href="#" name='install'></a>
 
-> :bulb: See[Docker](#docker) for ways to run that `panoptes-utils` without install.
+> :bulb: See [Docker](#docker) for ways to run that `panoptes-utils` without install.
 
 To install type:
 
@@ -31,7 +31,7 @@ pip install "panoptes-utils[all]"
 # Services
 <a href="#" name='services'></a>
 
-# Config Server
+## Config Server
 <a href="#" name='config-server'></a>
 
 A simple config param server. Runs as a Flask microservice that delivers JSON documents
@@ -51,7 +51,7 @@ For more details and usage examples, see the[config server README](panoptes / ut
 >> > server_process.terminate()  # Or just exit notebook/console
 ```
 
-# Messaging Hub
+## Messaging Hub
 <a href="#" name='messaging-hub'></a>
 
 The messaging hub is responsible for relaying zeromq messages between the various components of a
@@ -62,7 +62,7 @@ number of publishers and subscribers.
 panoptes - messaging - hub - -from-config
 ```
 
-# Docker
+## Docker
 <a name="docker"></a>
 
 Docker containers are available for running the `panoptes - utils` module and associated services, which

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
-[![PyPI version](https: // badge.fury.io / py / panoptes - utils.svg)](https: // badge.fury.io / py / panoptes - utils)
-[![Build Status](https: // travis - ci.com / panoptes / panoptes - utils.svg?branch=master)](https: // travis - ci.com / panoptes / panoptes - utils)
-[![codecov](https: // codecov.io / gh / panoptes / panoptes - utils / branch / master / graph / badge.svg)](https: // codecov.io / gh / panoptes / panoptes - utils)
-[![Documentation Status](https: // readthedocs.org / projects / panoptes - utils / badge /?version=latest)](https: // panoptes - utils.readthedocs.io / en / latest /?badge=latest)
+[![PyPI version](https://badge.fury.io/py/panoptes-utils.svg)](https://badge.fury.io/py/panoptes-utils)
+[![Build Status](https://travis-ci.com/panoptes/panoptes-utils.svg?branch=master)](https://travis-ci.com/panoptes/panoptes-utils)
+[![codecov](https://codecov.io/gh/panoptes/panoptes-utils/branch/master/graph/badge.svg)](https://codecov.io/gh/panoptes/panoptes-utils)
+[![Documentation Status](https://readthedocs.org/projects/panoptes-utils/badge/?version=latest)](https://panoptes-utils.readthedocs.io/en/latest/?badge=latest)
 
 # PANOPTES Utils
 
 Utility functions for use within the PANOPTES ecosystem and for general astronomical processing.
 
-See the full documentation at: https: // panoptes - utils.readthedocs.io
+See the full documentation at: https://panoptes-utils.readthedocs.io
 
 # Install
 <a href="#" name='install'></a>
 
->: bulb: See[Docker](  # docker) for ways to run that `panoptes-utils` without install.
+> :bulb: See[Docker](#docker) for ways to run that `panoptes-utils` without install.
 
 To install type:
 
 ```bash
-pip install panoptes - utils
+pip install panoptes-utils
 ```
 
 There are also a number of optional dependencies, which can be installed as following:
 
 ```bash
 pip install "panoptes-utils[google,mongo,social,test]"
-- or-
+# -or-
 pip install "panoptes-utils[all]"
 ```
 
@@ -68,4 +68,4 @@ panoptes - messaging - hub - -from-config
 Docker containers are available for running the `panoptes - utils` module and associated services, which
 also serve as the base container for all other PANOPTES related containers.
 
-See our[Docker documentation](https: // panoptes - utils.readthedocs.io / en / latest / docker.html) for details.
+See our [Docker documentation](https://panoptes-utils.readthedocs.io/en/latest/docker.html) for details.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ See the full documentation at: https://panoptes-utils.readthedocs.io
 # Install
 <a href="#" name='install'></a>
 
-> :bulb: See [Docker](#docker) for ways to run that `panoptes-utils` without install.
+> :bulb: See [Docker](#docker) for ways to run that `panoptes-utils` without installing
+to your hose computer.
 
 To install type:
 
@@ -37,7 +38,7 @@ pip install "panoptes-utils[all]"
 A simple config param server. Runs as a Flask microservice that delivers JSON documents
 in response to requests for config key items.
 
-For more details and usage examples, see the[config server README](panoptes / utils / config / README.md).
+For more details and usage examples, see the [config server README](panoptes/utils/config/README.md).
 
 ```python
 >> > from panoptes.utils.config.server import config_server
@@ -59,7 +60,7 @@ PANOPTES system. Running the Messaging Hub will set up a forwarding service that
 number of publishers and subscribers.
 
 ```bash
-panoptes - messaging - hub - -from-config
+panoptes-messaging-hub --from-config
 ```
 
 ## Docker

--- a/README.md
+++ b/README.md
@@ -35,11 +35,46 @@ pip install "panoptes-utils[all]"
 <a href="#" name='config-server'></a>
 
 A simple config param server. Runs as a Flask microservice that delivers JSON documents
-in response to requests for config key items. To start the service run:
+in response to requests for config key items.
+
+#### Starting the config server
+
+To start the service from the command-line, use `bin/panoptes-config-server`:
 
 ```bash
-run-config-server
+➜ bin/panoptes-config-server --help
+usage: panoptes-config-server [-h] [--host HOST] [--port PORT] [--public]
+                              [--config-file CONFIG_FILE] [--no-save]
+                              [--ignore-local] [--debug]
+
+Start the config server for PANOPTES
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --host HOST           Host name, defaults to local interface.
+  --port PORT           Local port, default 6563
+  --public              If server should be public, default False. Note:
+                        inside a docker container set this to True to expose
+                        to host.
+  --config-file CONFIG_FILE
+                        Config file, default $PANDIR/conf_files/pocs.yaml
+  --no-save             Prevent auto saving of any new values.
+  --ignore-local        Ignore the local config files, default False. Mostly
+                        for testing.
+  --debug               Debug
 ```
+
+From python, for instance when running in a jupyter notebook, you can use:
+
+```python
+>>> from panoptes.utils.config.server import config_server
+
+>>> config_server()
+```
+
+#### Using the config server
+
+##### Python
 
 The server can be queried/set in python:
 
@@ -78,6 +113,8 @@ The server can be queried/set in python:
 >>> client.get_config('cameras.devices[1].model')
 'canon_gphoto2'
 ```
+
+##### Command-line
 
 Since the Flask microservice just deals with JSON documents, you can also use
 [httpie](https://httpie.org/) and [jq](https://stedolan.github.io/jq/) from the command line to view

--- a/bin/panoptes-config-server
+++ b/bin/panoptes-config-server
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 
 import os
-from scalpl import Cut
 
-from panoptes.utils.config import load_config
-from panoptes.utils.config.server import app
+from panoptes.utils.config.server import config_server
 
 
 if __name__ == '__main__':
@@ -23,7 +21,7 @@ if __name__ == '__main__':
                         default=os.path.join(os.environ['PANDIR'], 'conf_files', 'pocs.yaml'),
                         help="Config file, default $PANDIR/conf_files/pocs.yaml")
     parser.add_argument('--no-save', default=False, action='store_true',
-                        help='Config entries are saved automatically by default.')
+                        help='Prevent auto saving of any new values.')
     parser.add_argument('--ignore-local', default=False, action='store_true',
                         help='Ignore the local config files, default False. Mostly for testing.')
     parser.add_argument('--debug', default=False, action='store_true', help='Debug')
@@ -33,25 +31,18 @@ if __name__ == '__main__':
     if args.public and args.host == '127.0.0.1':
         args.host = '0.0.0.0'
 
-    if not args.config_file:
-        # Look for $PANDIR/conf_files/.
-        conf_dir = os.path.join(os.getenv('PANDIR'), 'conf_files')
-
-        if os.path.isdir(conf_dir):
-            print(f'Using default config files from {conf_dir}/pocs.yaml')
-            args.config_file = os.path.join(conf_dir, 'pocs')
-        else:
-            print('No config files given')
-
-    app.config['auto_save'] = not args.no_save
-    app.config['config_file'] = args.config_file
-    app.config['ignore_local'] = args.ignore_local
-    app.config['POCS'] = load_config(config_files=args.config_file,
-                                     ignore_local=args.ignore_local)
-    app.config['POCS_cut'] = Cut(app.config['POCS'])
-
-    app.run(
+    # Handle Ctrl-c gracefully
+    server_process = config_server(
         host=args.host,
         port=args.port,
+        config_file=args.config_file,
+        ignore_local=args.ignore_local,
+        auto_save=not args.no_save,
         debug=args.debug,
+        auto_start=False
     )
+
+    try:
+        server_process.start()
+    except KeyboardInterrupt:
+        server_process.terminate()

--- a/bin/panoptes-config-server
+++ b/bin/panoptes-config-server
@@ -31,7 +31,6 @@ if __name__ == '__main__':
     if args.public and args.host == '127.0.0.1':
         args.host = '0.0.0.0'
 
-    # Handle Ctrl-c gracefully
     server_process = config_server(
         host=args.host,
         port=args.port,

--- a/panoptes/utils/config/README.md
+++ b/panoptes/utils/config/README.md
@@ -1,0 +1,141 @@
+# Config Server
+
+## Starting the config server
+
+To start the service from the command-line, use `bin/panoptes-config-server`:
+
+```bash
+➜ bin/panoptes-config-server --help
+usage: panoptes-config-server [-h] [--host HOST] [--port PORT] [--public]
+                              [--config-file CONFIG_FILE] [--no-save]
+                              [--ignore-local] [--debug]
+
+Start the config server for PANOPTES
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --host HOST           Host name, defaults to local interface.
+  --port PORT           Local port, default 6563
+  --public              If server should be public, default False. Note:
+                        inside a docker container set this to True to expose
+                        to host.
+  --config-file CONFIG_FILE
+                        Config file, default $PANDIR/conf_files/pocs.yaml
+  --no-save             Prevent auto saving of any new values.
+  --ignore-local        Ignore the local config files, default False. Mostly
+                        for testing.
+  --debug               Debug
+```
+
+From python, for instance when running in a jupyter notebook, you can use:
+
+```python
+>>> from panoptes.utils.config.server import config_server
+
+>>> server_process = config_server()
+...
+>>> server_process.terminate()  # Or just exit notebook/console
+```
+
+The following are options are available for the server:
+
+```
+  host (str, optional): Name of host, default 'localhost'.
+  port (int, optional): Port for server, default 6563.
+  config_file (str|None, optional): The config file to load, defaults to
+      `$PANDIR/conf_files/pocs.yaml`.
+  ignore_local (bool, optional): If local config files should be ignored,
+      default False.
+  auto_save (bool, optional): If setting new values should auto-save to
+      local file, default False.
+  auto_start (bool, optional): If server process should be started
+      automatically, default True.
+  debug (bool, optional): Flask server debug mode, default False.
+```
+
+## Using the config server
+
+### Python
+
+The server can be queried/set in python:
+
+```python
+>>> from panoptes.utils.config import client
+
+>>> client.get_config('location.horizon')
+30.0
+
+>>> client.set_config('location.horizon', 45)
+{'location.horizon': 45.0}
+
+>>> client.get_config('location.horizon')
+45.0
+
+>>> from astropy import units as u
+>>> client.set_config('location.horizon', 45 * u.deg)
+{'location.horizon': <Quantity 45. deg>}
+
+>>> client.get_config('location.horizon')
+<Quantity 45. deg>
+
+>>> client.get_config('location')
+{'elevation': 3400.0,
+ 'flat_horizon': -6.0,
+ 'focus_horizon': -12.0,
+ 'gmt_offset': -600.0,
+ 'horizon': <Quantity 45. deg>,
+ 'latitude': 19.54,
+ 'longitude': -155.58,
+ 'name': 'Mauna Loa Observatory',
+ 'observe_horizon': -18.0,
+ 'timezone': 'US/Hawaii'}
+
+# Get the second camera model
+>>> client.get_config('cameras.devices[1].model')
+'canon_gphoto2'
+```
+
+### Command-line
+
+Since the Flask microservice just deals with JSON documents, you can also use
+[httpie](https://httpie.org/) and [jq](https://stedolan.github.io/jq/) from the command line to view
+or manipulate the configuration:
+
+Get entire config, pipe through jq and select just location.
+
+```bash
+http :6563/get-config | jq '.location'
+{
+  "elevation": 3400,
+  "flat_horizon": -6,
+  "focus_horizon": -12,
+  "gmt_offset": -600,
+  "horizon": "45.0 deg",
+  "latitude": 19.54,
+  "longitude": -155.58,
+  "name": "Mauna Loa Observatory",
+  "observe_horizon": -18,
+  "timezone": "US/Hawaii"
+}
+```
+
+`jq` can easily manipulate the json documents. Here we pipe the original output into `jq`, change two of the values, then pipe
+the output back into the `set-config` endpoint provided by our Flask microservice. This will update the configuration on the server
+and return the updated configuration back to the user. We simply pipe this through `jq` yet again for an easy display of the new values.
+(Note the `jq` pipe `|` inside the single quotes see [jq](https://stedolan.github.io/jg/) for details.)
+
+```bash
+http :6563/get-config | jq '.location.horizon="37 deg" | .location.name="New Location"' | http :6563/set-config | jq '.location'
+{
+  "elevation": 3400,
+  "flat_horizon": -6,
+  "focus_horizon": -12,
+  "gmt_offset": -600,
+  "horizon": "37 deg",
+  "latitude": 19.54,
+  "longitude": -155.58,
+  "name": "New Location",
+  "observe_horizon": -18,
+  "timezone": "US/Hawaii"
+}
+```

--- a/panoptes/utils/config/README.md
+++ b/panoptes/utils/config/README.md
@@ -37,6 +37,23 @@ From python, for instance when running in a jupyter notebook, you can use:
 >>> server_process.terminate()  # Or just exit notebook/console
 ```
 
+## Options
+
+### ignore_local
+
+By default, local versions of the config files are parsed and replace any default
+values. For instance, the default config file is `$PANDIR/conf_files/pocs.yaml` but
+the config server will also look for and parse `$PANDIR/conf_files/pocs_local.yaml`.
+
+This allows for overriding of default entries while still maintaing the originals.
+
+### auto_save
+
+By default, changes to the config values (via `set_config`, set below) are not
+preserved across restarts. Use the `auto_save` option to enable saving. When
+enabled, this will write to the "local" version of the file (i.e. `pocs_local.yaml`
+for the `pocs.yaml` config file).
+
 The following are options are available for the server:
 
 ```

--- a/panoptes/utils/config/README.md
+++ b/panoptes/utils/config/README.md
@@ -47,6 +47,11 @@ the config server will also look for and parse `$PANDIR/conf_files/pocs_local.ya
 
 This allows for overriding of default entries while still maintaing the originals.
 
+This option can be disabled with the `ignore_local` setting.
+
+> **Note:** Automatic tests run via `pytest` will always ignore local config files
+unless they are being run with the `--hardware` options.
+
 ### auto_save
 
 By default, changes to the config values (via `set_config`, set below) are not

--- a/panoptes/utils/config/server.py
+++ b/panoptes/utils/config/server.py
@@ -1,14 +1,19 @@
+import logging
+from warnings import warn
 from flask import Flask
 from flask import request
 from flask import jsonify
 from flask.json import JSONEncoder
 
+from multiprocessing import Process
 from scalpl import Cut
 
 from panoptes.utils.config import load_config
 from panoptes.utils.config import save_config
 from panoptes.utils.serializers import _serialize_object
 from panoptes.utils.logger import get_root_logger
+
+logging.getLogger('werkzeug').setLevel(logging.INFO)
 
 app = Flask(__name__)
 
@@ -20,6 +25,59 @@ class CustomJSONEncoder(JSONEncoder):
 
 
 app.json_encoder = CustomJSONEncoder
+
+
+def config_server(host='localhost',
+                  port=6563,
+                  config_file=None,
+                  ignore_local=False,
+                  auto_save=False,
+                  auto_start=True,
+                  debug=False):
+    """Start the config server in a separate process.
+
+    A convenience function to start the config server.
+
+    Args:
+        host (str, optional): Name of host, default 'localhost'.
+        port (int, optional): Port for server, default 6563.
+        config_file (str|None, optional): The config file to load, defaults to
+            `$PANDIR/conf_files/pocs.yaml`.
+        ignore_local (bool, optional): If local config files should be ignored,
+            default False.
+        auto_save (bool, optional): If setting new values should auto-save to
+            local file, default False.
+        auto_start (bool, optional): If server process should be started
+            automatically, default True.
+        debug (bool, optional): Flask server debug mode, default False.
+
+    Returns:
+        `multiprocessing.Process`: The process running the config server.
+    """
+    app.config['auto_save'] = auto_save
+    app.config['config_file'] = config_file
+    app.config['ignore_local'] = ignore_local
+    app.config['POCS'] = load_config(config_files=config_file, ignore_local=ignore_local)
+    app.config['POCS_cut'] = Cut(app.config['POCS'])
+
+    def start_server(**kwargs):
+        try:
+            app.run(**kwargs)
+        except OSError:
+            warn(f'Problem starting config server, is another config server already running?')
+            return None
+
+    server_process = Process(target=start_server,
+                             kwargs=dict(host=host, port=port, debug=debug),
+                             name='panoptes-config-server')
+
+    if server_process is not None and auto_start:
+        try:
+            server_process.start()
+        except KeyboardInterrupt:
+            server_process.terminate()
+
+    return server_process
 
 
 @app.route('/get-config', methods=['GET', 'POST'])
@@ -39,7 +97,7 @@ def get_config_entry():
     For example, take the following configuration:
 
     ```
-    { 
+    {
         'location': {
             'elevation': 3400.0,
         }


### PR DESCRIPTION
Adds a function that will start the config server in a separate process. Can be used to start and kill an instance of the server easily.

Cleanup to scripts and testing.