### PR TITLE
Better crop utility

### DIFF
--- a/panoptes/utils/images/__init__.py
+++ b/panoptes/utils/images/__init__.py
@@ -40,7 +40,7 @@ def make_images_dir():
         return None
 
 
-def crop_data(data, box_width=200, center=None, verbose=False, data_only=True):
+def crop_data(data, box_width=200, center=None, verbose=False, data_only=True, wcs=None):
     """Return a cropped portion of the image
 
     Shape is a box centered around the middle of the data
@@ -52,6 +52,8 @@ def crop_data(data, box_width=200, center=None, verbose=False, data_only=True):
         verbose (bool, optional): Print extra text output.
         data_only (bool, optional): If True (default), return only data. If False
             return the `Cutout2D` object.
+        wcs (None|`astropy.wcs.WCS`, optional): A valid World Coordinate System (WCS) that will
+            be cropped along with the data if provided.
 
     Returns:
         np.array: A clipped (thumbnailed) version of the data if `data_only=True`, otherwise
@@ -76,7 +78,7 @@ def crop_data(data, box_width=200, center=None, verbose=False, data_only=True):
         print("Using center: {} {}".format(x_center, y_center))
         print("Box width: {}".format(box_width))
 
-    cutout = Cutout2D(data, (x_center, y_center), box_width)
+    cutout = Cutout2D(data, (x_center, y_center), box_width, wcs=wcs)
 
     if data_only:
         return cutout.data

--- a/panoptes/utils/tests/test_image_utils.py
+++ b/panoptes/utils/tests/test_image_utils.py
@@ -4,6 +4,8 @@ import pytest
 import shutil
 import tempfile
 
+from astropy.nddata import Cutout2D
+
 from panoptes.utils import images as img_utils
 from panoptes.utils import error
 
@@ -36,6 +38,18 @@ def test_crop_data():
 
     cropped03 = img_utils.crop_data(ones, verbose=True, box_width=6, center=(50, 50))
     assert cropped03.sum() == 36.
+
+    # Test the Cutout2D object
+    cropped04 = img_utils.crop_data(ones,
+                                    verbose=True,
+                                    box_width=20,
+                                    center=(50, 50),
+                                    data_only=False)
+    assert isinstance(cropped04, Cutout2D)
+    assert cropped04.position_original == (50, 50)
+
+    # Box is 20 pixels wide so center is at 10,10
+    assert cropped04.position_cutout == (10, 10)
 
 
 def test_make_pretty_image(solved_fits_file, tiny_fits_file, save_environ):

--- a/panoptes/utils/tests/test_image_utils.py
+++ b/panoptes/utils/tests/test_image_utils.py
@@ -30,7 +30,7 @@ def test_crop_data():
     ones = np.ones((201, 201))
     assert ones.sum() == 40401.
 
-    cropped01 = img_utils.crop_data(ones, verbose=True)
+    cropped01 = img_utils.crop_data(ones, verbose=False)  # False to exercise coverage.
     assert cropped01.sum() == 40000.
 
     cropped02 = img_utils.crop_data(ones, verbose=True, box_width=10)


### PR DESCRIPTION
Updates the `crop_data` utility function to use `astropy.nddata.Cutout2D` under the hood, which allows for passing a WCS and getting a crop of the WCS as well.  The function now has a parameter, `data_only` that is `True` by default and mimics the behvaiour of just returning the data. If `data_only=False` then the `Cutout2D` object is returned.