### PR TITLE
Handle dict keys and values appropriately.

### DIFF
--- a/panoptes/utils/tests/test_utils.py
+++ b/panoptes/utils/tests/test_utils.py
@@ -56,6 +56,18 @@ def test_empty_listify():
     assert listify(None) == []
 
 
+def test_listfy_dicts():
+    d = dict(a=42)
+
+    d_vals = d.values()
+    d_keys = d.keys()
+
+    assert isinstance(listify(d_vals), list)
+    assert listify(d_vals) == list(d_vals)
+    assert isinstance(listify(d_keys), list)
+    assert listify(d_keys) == list(d_keys)
+
+
 def test_pretty_time():
     t0 = '2016-08-13 10:00:00'
     os.environ['POCSTIME'] = t0
@@ -93,6 +105,7 @@ def test_countdown_timer_non_blocking():
         timer = CountdownTimer(arg)
         assert timer.duration == expected_duration
 
+
 def test_countdown_timer():
     count_time = 1
     timer = CountdownTimer(count_time)
@@ -108,6 +121,7 @@ def test_countdown_timer():
     assert counter == pytest.approx(1)
     assert timer.time_left() == 0
     assert timer.expired() is True
+
 
 def test_countdown_timer_sleep():
     count_time = 1

--- a/panoptes/utils/tests/test_utils.py
+++ b/panoptes/utils/tests/test_utils.py
@@ -64,8 +64,12 @@ def test_listfy_dicts():
 
     assert isinstance(listify(d_vals), list)
     assert listify(d_vals) == list(d_vals)
+
     assert isinstance(listify(d_keys), list)
     assert listify(d_keys) == list(d_keys)
+
+    assert isinstance(listify(d), list)
+    assert listify(d) == list(d_vals)
 
 
 def test_pretty_time():

--- a/panoptes/utils/utils.py
+++ b/panoptes/utils/utils.py
@@ -23,6 +23,9 @@ def listify(obj):
     if obj is list, just returns obj, otherwise returns list with
     obj as single member.
 
+    If a `dict` object is passed then this function will return a list of *only*
+    the values.
+
     Returns:
         list:   You guessed it.
     """
@@ -30,6 +33,8 @@ def listify(obj):
         return list()
     elif isinstance(obj, list):
         return obj
+    elif isinstance(obj, dict):
+        return list(obj.values())
     elif isinstance(obj, (collections.abc.ValuesView, collections.abc.KeysView)):
         return list(obj)
     else:

--- a/panoptes/utils/utils.py
+++ b/panoptes/utils/utils.py
@@ -26,6 +26,26 @@ def listify(obj):
     If a `dict` object is passed then this function will return a list of *only*
     the values.
 
+    .. doctest::
+
+        >>> listify(42)
+        [42]
+        >>> listify('foo')
+        ['foo']
+        >>> listify(None)
+        []
+        >>> listify(['a'])
+        ['a']
+
+        >>> my_dict = dict(a=42, b='foo')
+        >>> listify(my_dict)
+        [42, 'foo']
+        >>> listify(my_dict.values())
+        [42, 'foo']
+        >>> listify(my_dict.keys())
+        ['a', 'b']
+
+
     Returns:
         list:   You guessed it.
     """

--- a/panoptes/utils/utils.py
+++ b/panoptes/utils/utils.py
@@ -3,6 +3,7 @@ import os
 import re
 import shutil
 import signal
+import collections.abc
 
 import numpy as np
 from astropy import units as u
@@ -26,9 +27,13 @@ def listify(obj):
         list:   You guessed it.
     """
     if obj is None:
-        return []
+        return list()
+    elif isinstance(obj, list):
+        return obj
+    elif isinstance(obj, (collections.abc.ValuesView, collections.abc.KeysView)):
+        return list(obj)
     else:
-        return obj if isinstance(obj, (list, type(None))) else [obj]
+        return [obj]
 
 
 def get_free_space(dir=None):


### PR DESCRIPTION
Current behavior returns a list of dict_values or dict_keys. Current behaviour just wraps the dict_values in a list, e.g. `[dict_values('x')]` instead of `[x]`

May help with the autofocus breaking we are seeing in https://github.com/AstroHuntsman/huntsman-pocs 