### PR TITLE
POCS Merge Updates

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-# This is in the root PANDIR directory so that pytest will recognize the
+s# This is in the root PANDIR directory so that pytest will recognize the
 # options added below without having to also specify pocs/test, or a
 # one of the tests in that directory, on the command line; i.e. pytest
 # doesn't load pocs/tests/conftest.py until after it has searched for
@@ -12,12 +12,8 @@ import pytest
 import subprocess
 import time
 import shutil
-from multiprocessing import Process
-
-from scalpl import Cut
 
 from panoptes.utils.database import PanDB
-from panoptes.utils.config import load_config
 from panoptes.utils.logger import get_root_logger
 from panoptes.utils.messaging import PanMessaging
 from panoptes.utils.config.client import set_config

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-s# This is in the root PANDIR directory so that pytest will recognize the
+# This is in the root PANDIR directory so that pytest will recognize the
 # options added below without having to also specify pocs/test, or a
 # one of the tests in that directory, on the command line; i.e. pytest
 # doesn't load pocs/tests/conftest.py until after it has searched for

--- a/panoptes/utils/config/client.py
+++ b/panoptes/utils/config/client.py
@@ -56,7 +56,7 @@ def get_config(key=None, host='localhost', port='6563', parse=True, default=None
         get_root_logger().info(f'Problem with get_config: {e!r}')
     else:
         if not response.ok:
-            get_root_logger().warning(f'Problem with config-server: {response.content!r}')
+            get_root_logger().info(f'Problem with get_config: {response.content!r}')
         else:
             if response.text != 'null\n':
                 if parse:

--- a/panoptes/utils/config/client.py
+++ b/panoptes/utils/config/client.py
@@ -64,6 +64,9 @@ def get_config(key=None, host='localhost', port='6563', parse=True, default=None
                 else:
                     config_entry = response.json()
 
+    if config_entry is None:
+        config_entry = default
+
     return config_entry
 
 

--- a/panoptes/utils/config/server.py
+++ b/panoptes/utils/config/server.py
@@ -126,7 +126,10 @@ def get_config_entry():
             # Return all
             show_config = app.config['POCS']
         else:
-            show_config = app.config['POCS_cut'].get(key, None)
+            try:
+                show_config = app.config['POCS_cut'].get(key, None)
+            except KeyError:
+                show_config = None
     else:
         # Return entire config
         show_config = app.config['POCS']

--- a/panoptes/utils/database/file.py
+++ b/panoptes/utils/database/file.py
@@ -35,11 +35,12 @@ class PanFileDB(AbstractPanDB):
         obj = create_storage_obj(collection, obj, obj_id=obj_id)
         current_fn = self._get_file(collection, permanent=False)
         result = obj_id
+
         try:
             # Overwrite current collection file with obj.
             to_json(obj, filename=current_fn, append=False)
         except Exception as e:
-            self._warn("Problem inserting object into current collection: {}, {!r}".format(e, obj))
+            self._warn(f"Problem serializing object for insertion: {e} {current_fn} {obj!r}")
             result = None
 
         if not store_permanently:
@@ -48,7 +49,7 @@ class PanFileDB(AbstractPanDB):
         collection_fn = self._get_file(collection)
         try:
             # Append obj to collection file.
-            to_json(obj, filename=collection_fn)
+            to_json(obj, filename=collection_fn, append=True)
             return obj_id
         except Exception as e:
             self._warn("Problem inserting object into collection: {}, {!r}".format(e, obj))

--- a/panoptes/utils/library.py
+++ b/panoptes/utils/library.py
@@ -5,7 +5,7 @@ from astropy.utils import resolve_name
 from panoptes.utils import error
 
 
-def load_c_library(name, path=None, logger=None):
+def load_c_library(name, path=None, mode=ctypes.DEFAULT_MODE, logger=None):
     """Utility function to load a shared/dynamically linked library (.so/.dylib/.dll).
 
     The name and location of the shared library can be manually specified with the library_path
@@ -15,15 +15,22 @@ def load_c_library(name, path=None, logger=None):
     Args:
         name (str): name of the library (without 'lib' prefix or any suffixes, e.g. 'fli').
         path (str, optional): path to the library e.g. '/usr/local/lib/libfli.so'.
+        mode (int, optional): mode in which to load the library, see dlopen(3) man page for
+            details. Should be one of ctypes.RTLD_GLOBAL, ctypes.RTLD_LOCAL, or
+            ctypes.DEFAULT_MODE. Default is ctypes.DEFAULT_MODE.
+        logger (logging.Logger, optional): logger to use.
 
     Returns:
         ctypes.CDLL
 
     Raises:
-        panoptes.utils.error.NotFound: raised if library_path not given & find_libary fails to
+        pocs.utils.error.NotFound: raised if library_path not given & find_library fails to
             locate the library.
         OSError: raises if the ctypes.CDLL loader cannot load the library.
     """
+    if mode is None:
+        # Interpret a value of None as the default.
+        mode = ctypes.DEFAULT_MODE
     # Open library
     if logger:
         logger.debug("Opening {} library".format(name))
@@ -32,7 +39,7 @@ def load_c_library(name, path=None, logger=None):
         if not path:
             raise error.NotFound("Cound not find {} library!".format(name))
     # This CDLL loader will raise OSError if the library could not be loaded
-    return ctypes.CDLL(path)
+    return ctypes.CDLL(path, mode=mode)
 
 
 def load_module(module_name):

--- a/panoptes/utils/serializers.py
+++ b/panoptes/utils/serializers.py
@@ -286,7 +286,7 @@ def _parse_all_objects(obj):
         return bool(obj)
 
     # Try to turn into a time
-    with suppress(ValueError):
+    with suppress(KeyError, ValueError):
         if isinstance(Time(obj), Time):
             return Time(obj).datetime
 

--- a/panoptes/utils/tests/test_config_server.py
+++ b/panoptes/utils/tests/test_config_server.py
@@ -21,6 +21,18 @@ def test_config_client(dynamic_config_server, config_port):
     assert get_config('location.horizon', port=config_port, parse=False) == '47.0 deg'
 
 
+def test_config_client_bad(dynamic_config_server, config_port, caplog):
+    # Bad host will return `None` but also throw error
+    assert set_config('foo', 42, host='foobaz') is None
+    assert caplog.records[-1].levelname == "INFO"
+    assert caplog.records[-1].message.startswith("Problem with set_config")
+
+    # Bad host will return `None` but also throw error
+    assert get_config('foo', host='foobaz') is None
+    assert caplog.records[-1].levelname == "INFO"
+    assert caplog.records[-1].message.startswith("Problem with get_config")
+
+
 def test_config_reset(dynamic_config_server, config_port, config_host):
     # Check we are at default.
     assert get_config('location.horizon', port=config_port) == 30 * u.degree

--- a/panoptes/utils/tests/test_serializers.py
+++ b/panoptes/utils/tests/test_serializers.py
@@ -2,6 +2,7 @@ import pytest
 
 from astropy import units as u
 
+from panoptes.utils import current_time
 from panoptes.utils import serializers
 
 
@@ -12,9 +13,9 @@ def obj():
         "pan_id": "PAN000",
         "location": {
             "name": "Mauna Loa Observatory",
-            "latitude": 19.54 * u.degree,
-            "longitude": -155.58 * u.degree,
-            "elevation": 3400.0,
+            "latitude": 19.54 * u.degree,       # Astropy unit
+            "longitude": "-155.58 deg",         # String unit
+            "elevation": "3400.0 m",
             "horizon": 30 * u.degree,
             "flat_horizon": -6 * u.degree,
             "focus_horizon": -12 * u.degree,
@@ -33,7 +34,11 @@ def obj():
         "db": {
             "name": "panoptes",
             "type": "file"
-        }
+        },
+        "empty": {},
+        "current_time": current_time(),
+        "bool": True,
+
     }
 
 

--- a/panoptes/utils/tests/test_utils.py
+++ b/panoptes/utils/tests/test_utils.py
@@ -12,6 +12,7 @@ from panoptes.utils import CountdownTimer
 from panoptes.utils import error
 from panoptes.utils.library import load_module
 from panoptes.utils.library import load_c_library
+from panoptes.utils.logger import get_root_logger
 
 
 def test_error(capsys):
@@ -45,6 +46,15 @@ def test_load_c_library():
     # Called without a `path` this will use find_library to locate libc.
     libc = load_c_library('c')
     assert libc._name[:4] == 'libc'
+
+    libc = load_c_library('c', mode=None, logger=get_root_logger())
+    assert libc._name[:4] == 'libc'
+
+
+def test_load_c_library_fail():
+    # Called without a `path` this will use find_library to locate libc.
+    with pytest.raises(error.NotFound):
+        load_c_library('foobar')
 
 
 def test_listify():


### PR DESCRIPTION
Changes for panoptes-utils derived from upstream POCS changes. Part of https://github.com/panoptes/POCS/pull/951

* Config server will return `None` rather than raise exception and fail.
* :beetle:  Handle empty dict in serializer ~~(note that this duplicates #85 although that adds tests)~~
* Updates to `load_c_library` (https://github.com/panoptes/POCS/commit/d5cf73755a08a2e2d6ed2e5d5565ac7507c9ed2c)
* Tests and cleanup.