### PR TITLE
Exception fixes:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 
 * Misc bugs introduced as part of last release, including to `download-data.py` script.
+* Custom exceptions now properly pass `kwargs` through to parent (#135).
 
 ### Changed
 
 * New script for downloading data, `scripts/download-data.py`. This helped resolve some issues with the relative imports introduced in `v0.2.0` and is cleaner. (#129)
+
+### Removed
+
+* The `get_root_logger` and associated tests (#134).
 
 ## [0.2.0] - 2020-03-04
 

--- a/panoptes/utils/error.py
+++ b/panoptes/utils/error.py
@@ -6,10 +6,10 @@ class PanError(Exception):
 
     """ Base class for Panoptes errors """
 
-    def __init__(self, msg=None, log=False, exit=False):
+    def __init__(self, msg=None, exit=False):
         self.msg = msg
 
-        if self.msg and log:
+        if self.msg:
             logger.error(str(self))
 
         if exit:
@@ -20,7 +20,9 @@ class PanError(Exception):
         if not msg:
             self.msg = 'No reason specified'
 
-        print("TERMINATING: {}".format(self.msg))
+        # Show on current display.
+        logger.add(sys.stderr, format='<red><b>{message}</></>')
+        logger.critical(f"TERMINATING: {self.msg}")
         sys.exit(1)
 
     def __str__(self):
@@ -35,40 +37,40 @@ class InvalidSystemCommand(PanError):
 
     """ Error for a system level command malfunction """
 
-    def __init__(self, msg='Problem running system command'):
-        super().__init__(msg)
+    def __init__(self, msg='Problem running system command', **kwargs):
+        super().__init__(msg, **kwargs)
 
 
 class InvalidDeserialization(PanError):
 
     """ Error for serialization errors """
 
-    def __init__(self, msg='Problem deserializing'):
-        super().__init__(msg)
+    def __init__(self, msg='Problem deserializing', **kwargs):
+        super().__init__(msg, **kwargs)
 
 
 class InvalidSerialization(PanError):
 
     """ Error for serialization errors """
 
-    def __init__(self, msg='Problem Serializing'):
-        super().__init__(msg)
+    def __init__(self, msg='Problem Serializing', **kwargs):
+        super().__init__(msg, **kwargs)
 
 
 class Timeout(PanError):
 
     """ Error called when an event times out """
 
-    def __init__(self, msg='Timeout waiting for event'):
-        super().__init__(msg)
+    def __init__(self, msg='Timeout waiting for event', **kwargs):
+        super().__init__(msg, **kwargs)
 
 
 class NoObservation(PanError):
 
     """ Generic no Observation """
 
-    def __init__(self, msg='No valid observations found.'):
-        super().__init__(msg)
+    def __init__(self, msg='No valid observations found.', **kwargs):
+        super().__init__(msg, **kwargs)
 
 
 class NotFound(PanError):
@@ -126,8 +128,8 @@ class MountNotFound(NotFound):
 
     """ Mount cannot be import """
 
-    def __init__(self, msg='Mount Not Found'):
-        super().__init__(msg)
+    def __init__(self, msg='Mount Not Found', **kwargs):
+        super().__init__(msg, **kwargs)
 
 
 class CameraNotFound(NotFound):

--- a/panoptes/utils/tests/test_errors.py
+++ b/panoptes/utils/tests/test_errors.py
@@ -3,7 +3,7 @@ import pytest
 from panoptes.utils import error
 
 
-def test_error(capsys):
+def test_error(capsys, caplog):
     with pytest.raises(error.PanError) as e_info:
         raise error.PanError(msg='Testing message')
 
@@ -17,9 +17,9 @@ def test_error(capsys):
     with pytest.raises(SystemExit) as e_info:
         raise error.PanError(msg="Testing exit", exit=True)
     assert e_info.type == SystemExit
-    assert capsys.readouterr().out.strip() == 'TERMINATING: Testing exit'
+    assert caplog.records[-1].message == 'TERMINATING: Testing exit'
 
     with pytest.raises(SystemExit) as e_info:
         raise error.PanError(exit=True)
     assert e_info.type == SystemExit
-    assert capsys.readouterr().out.strip() == 'TERMINATING: No reason specified'
+    assert caplog.records[-1].message == 'TERMINATING: No reason specified'


### PR DESCRIPTION
* Always log the error message.
* If exiting, add handler to display message in terminal.
* Properly pass `kwargs` from child exceptions (so you can actually exit)