### PR TITLE
Fix namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - [Added](#added-4)
     - [Changed](#changed-5)
 
+## [Unreleased]
+
+### Changed
+
+* Fixed top-level namespace so we can have other `panoptes` repos (#).
+
 ## [0.2.2] - 2020-03-05
 
-Mostly some cleanup from the `v0.2.0` release based on integrating all the changes into POCS. 
+Mostly some cleanup from the `v0.2.0` release based on integrating all the changes into POCS.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Fixed top-level namespace so we can have other `panoptes` repos (#).
+* Fixed top-level namespace so we can have other `panoptes` repos (#137).
 
 ## [0.2.2] - 2020-03-05
 

--- a/panoptes/__init__.py
+++ b/panoptes/__init__.py
@@ -1,3 +1,0 @@
-from .utils.logger import logger
-
-logger.disable('panoptes')

--- a/panoptes/utils/__init__.py
+++ b/panoptes/utils/__init__.py
@@ -1,4 +1,4 @@
-from .utils.logger import logger
+from .logger import logger
 from .utils import *
 from .time import *
 

--- a/panoptes/utils/__init__.py
+++ b/panoptes/utils/__init__.py
@@ -1,6 +1,9 @@
+from .utils.logger import logger
 from .utils import *
 from .time import *
 
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+logger.disable('panoptes')

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@
 from configparser import ConfigParser
 from setuptools import setup, find_namespace_packages
 
-import itertools
-
 import versioneer
 
 
@@ -76,7 +74,8 @@ setup(name=NAME,
           'bin/panoptes-solve-field',
       ],
       install_requires=modules['required'],
-      packages=find_namespace_packages(exclude=['tests', 'test_*']),
+      packages=find_namespace_packages(include=['panoptes.*'],
+                                       exclude=['tests', 'test_*']),
       classifiers=[
           'Development Status :: 3 - Alpha',
           'Environment :: Console',


### PR DESCRIPTION
In order to properly use the `panoptes` namespace in other repos we need to drop the top level init.

See [docs](https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages)