### PR TITLE
Remove some modules that will be deprecated soon.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-* Dependencies that will be deprecated soon and are causing bloat: `photutils`, `scipy`, `scikit-image`. #138
+* Dependencies that will be deprecated soon and are causing bloat: `photutils`, `scikit-image`. #138
 
 ## [0.2.2] - 2020-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed top-level namespace so we can have other `panoptes` repos (#137).
 
+### Removed
+
+* Dependencies that will be deprecated soon and are causing bloat: `photutils`, `scipy`, `scikit-image`. #138
+
 ## [0.2.2] - 2020-03-05
 
 Mostly some cleanup from the `v0.2.0` release based on integrating all the changes into POCS.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile
 #
 astroplan==0.6            # via panoptes-utils (setup.py)
-astropy==4.0              # via astroplan, panoptes-utils (setup.py), photutils
+astropy==4.0              # via astroplan, panoptes-utils (setup.py)
 attrs==19.3.0             # via pytest
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
@@ -14,26 +14,22 @@ codecov==2.0.16           # via panoptes-utils (setup.py)
 coverage==5.0.3           # via codecov, coveralls, panoptes-utils (setup.py), pytest-cov
 coveralls==1.11.1         # via panoptes-utils (setup.py)
 cycler==0.10.0            # via matplotlib
-decorator==4.4.1          # via mocket, networkx
+decorator==4.4.1          # via mocket
 docopt==0.6.2             # via coveralls
 flask==1.1.1              # via panoptes-utils (setup.py)
 idna==2.9                 # via requests
-imageio==2.6.1            # via scikit-image
 importlib-metadata==1.5.0  # via pluggy, pytest
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.1            # via flask
 kiwisolver==1.1.0         # via matplotlib
 loguru==0.4.1             # via panoptes-utils (setup.py)
 markupsafe==1.1.1         # via jinja2
-matplotlib==3.1.3         # via panoptes-utils (setup.py), scikit-image
+matplotlib==3.1.3         # via panoptes-utils (setup.py)
 mocket==3.8.4             # via panoptes-utils (setup.py)
 more-itertools==8.2.0     # via pytest
-networkx==2.4             # via scikit-image
-numpy==1.18.1             # via astroplan, astropy, imageio, matplotlib, panoptes-utils (setup.py), photutils, pywavelets, scipy
+numpy==1.18.1             # via astroplan, astropy, matplotlib, panoptes-utils (setup.py)
 oauthlib==3.1.0           # via requests-oauthlib
 packaging==20.3           # via pytest
-photutils==0.7.2          # via panoptes-utils (setup.py)
-pillow==7.0.0             # via imageio, scikit-image
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
 pycodestyle==2.5.0        # via panoptes-utils (setup.py)
@@ -46,7 +42,6 @@ pytest==5.3.5             # via panoptes-utils (setup.py), pytest-cov, pytest-re
 python-dateutil==2.8.1    # via matplotlib, panoptes-utils (setup.py)
 python-magic==0.4.15      # via mocket
 pytz==2019.3              # via astroplan
-pywavelets==1.1.1         # via scikit-image
 pyyaml==5.3               # via panoptes-utils (setup.py)
 pyzmq==18.1.1             # via panoptes-utils (setup.py)
 requests-oauthlib==1.3.0  # via tweepy
@@ -54,8 +49,6 @@ requests==2.23.0          # via codecov, coveralls, panoptes-utils (setup.py), r
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via panoptes-utils (setup.py)
 scalpl==0.3.0             # via panoptes-utils (setup.py)
-scikit-image==0.16.2      # via panoptes-utils (setup.py)
-scipy==1.4.1              # via panoptes-utils (setup.py), scikit-image
 six==1.14.0               # via astroplan, cycler, mocket, packaging, pytest-remotedata, python-dateutil, tweepy
 tweepy==3.8.0             # via panoptes-utils (setup.py)
 urllib3==1.25.8           # via mocket, requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ markupsafe==1.1.1         # via jinja2
 matplotlib==3.1.3         # via panoptes-utils (setup.py)
 mocket==3.8.4             # via panoptes-utils (setup.py)
 more-itertools==8.2.0     # via pytest
-numpy==1.18.1             # via astroplan, astropy, matplotlib, panoptes-utils (setup.py)
+numpy==1.18.1             # via astroplan, astropy, matplotlib, panoptes-utils (setup.py), scipy
 oauthlib==3.1.0           # via requests-oauthlib
 packaging==20.3           # via pytest
 pluggy==0.13.1            # via pytest
@@ -49,6 +49,7 @@ requests==2.23.0          # via codecov, coveralls, panoptes-utils (setup.py), r
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via panoptes-utils (setup.py)
 scalpl==0.3.0             # via panoptes-utils (setup.py)
+scipy==1.4.1              # via panoptes-utils (setup.py)
 six==1.14.0               # via astroplan, cycler, mocket, packaging, pytest-remotedata, python-dateutil, tweepy
 tweepy==3.8.0             # via panoptes-utils (setup.py)
 urllib3==1.25.8           # via mocket, requests

--- a/setup.py
+++ b/setup.py
@@ -26,33 +26,33 @@ modules = {
     'required': [
         'astroplan>=0.6',
         'astropy>=4.0.0',
-        'Flask',
-        'loguru',
-        'matplotlib>=3.0.0',
-        'numpy',
-        'pyserial',
-        'python-dateutil',
-        'PyYAML',
-        'pyzmq',
-        'ruamel.yaml>=0.15',
-        'scalpl',
-        'versioneer',
-        'requests',  # social
-        'tweepy',  # social
         'codecov',  # testing
         'coverage',  # testing
         'coveralls',  # testing
+        'Flask',
+        'loguru',
+        'matplotlib>=3.0.0',
         'mocket',  # testing
+        'numpy',
         'pycodestyle',  # testing
+        'pyserial',
         'pytest',  # testing
         'pytest-cov',  # testing
         'pytest-remotedata>=0.3.1',  # testing
+        'python-dateutil',
+        'PyYAML',
+        'pyzmq',
+        'requests',  # social
+        'ruamel.yaml>=0.15',
+        'scalpl',
+        'scipy',
+        'tweepy',  # social
+        'versioneer',
     ],
     'extras': {
         'dev': [
             'photutils',
             'scikit-image',
-            'scipy',
         ]
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -48,11 +48,13 @@ modules = {
         'pytest-cov',  # testing
         'pytest-remotedata>=0.3.1',  # testing
     ],
-    'dev': [
-        'photutils',
-        'scikit-image',
-        'scipy',
-    ]
+    'extras': {
+        'dev': [
+            'photutils',
+            'scikit-image',
+            'scipy',
+        ]
+    }
 }
 
 
@@ -76,7 +78,7 @@ setup(name=NAME,
           'bin/panoptes-solve-field',
       ],
       install_requires=modules['required'],
-      extras_require=modules['dev'],
+      extras_require=modules['extras'],
       packages=find_namespace_packages(include=['panoptes.*'],
                                        exclude=['tests', 'test_*']),
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -30,15 +30,12 @@ modules = {
         'loguru',
         'matplotlib>=3.0.0',
         'numpy',
-        'photutils',
         'pyserial',
         'python-dateutil',
         'PyYAML',
         'pyzmq',
         'ruamel.yaml>=0.15',
         'scalpl',
-        'scikit-image',
-        'scipy',
         'versioneer',
         'requests',  # social
         'tweepy',  # social
@@ -51,6 +48,11 @@ modules = {
         'pytest-cov',  # testing
         'pytest-remotedata>=0.3.1',  # testing
     ],
+    'dev': [
+        'photutils',
+        'scikit-image',
+        'scipy',
+    ]
 }
 
 
@@ -74,6 +76,7 @@ setup(name=NAME,
           'bin/panoptes-solve-field',
       ],
       install_requires=modules['required'],
+      extras_require=modules['dev'],
       packages=find_namespace_packages(include=['panoptes.*'],
                                        exclude=['tests', 'test_*']),
       classifiers=[


### PR DESCRIPTION
The have been moved to the `dev` extras and can be installed with `pip install panoptes-utils[dev]` (or just `.[dev]` if you are inside the directory).