### PR TITLE
Fix for 'panoptes' namespace across distributions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - [Added](#added-4)
     - [Changed](#changed-5)
 
-## [0.2.3]
+## [Unreleased]
+
+### Changed
+
+* Disallow zipped packages, which also interfere with namespace (#142)
+
+## [0.2.3] - 2020-03-08
 
 Small point release to correct namespace and remove some bloat.
 

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(name=NAME,
       ],
       install_requires=modules['required'],
       extras_require=modules['extras'],
-      packages=find_namespace_packages(include=['panoptes.*'],
+      packages=find_namespace_packages(include=['panoptes.utils.*'],
                                        exclude=['tests', 'test_*']),
       classifiers=[
           'Development Status :: 3 - Alpha',
@@ -95,4 +95,5 @@ setup(name=NAME,
           'Topic :: Scientific/Engineering :: Astronomy',
           'Topic :: Scientific/Engineering :: Physics',
       ],
+      zip_safe=False
       )


### PR DESCRIPTION
* Explicit namespace search.
* Also removing zips. See note at bottom of: https://github.com/pypa/sample-namespace-packages