### PR TITLE
Allow for RGB background object to be returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * `get_stars_from_footprint` can accept a `WCS` directly instead of just the output from `calc_footprint()`. (#164)
+* `get_rgb_backgrounds(return_separate)` will now return the `Background2D` objects. (#166)
 
 ### Bug fixes
 

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -199,10 +199,8 @@ def get_rgb_background(fits_fn,
     2202.392...
 
     >>> rgb_backs = get_rgb_background(fits_fn, return_separate=True)
-    >>> rgb_backs
-    [<photutils.background.background_2d.Background2D at 0x...>,
-     <photutils.background.background_2d.Background2D at 0x...>,
-     <photutils.background.background_2d.Background2D at 0x...>]
+    >>> rgb_backs[0]
+    <photutils.background.background_2d.Background2D...>
     >>> {color:data.background_rms_median for color, data in zip('rgb', rgb_backs)}
     {'r': 20.566..., 'g': 32.787..., 'b': 23.820...}
 

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -198,9 +198,13 @@ def get_rgb_background(fits_fn,
     >>> rgb_back.mean()
     2202.392...
 
-    >>> rgb_back = get_rgb_background(fits_fn, return_separate=True)
-    >>> [np.ma.median(x) for x in rgb_back]
-    [2144.411..., 2241.219..., 2182.822...]
+    >>> rgb_backs = get_rgb_background(fits_fn, return_separate=True)
+    >>> rgb_backs
+    [<photutils.background.background_2d.Background2D at 0x...>,
+     <photutils.background.background_2d.Background2D at 0x...>,
+     <photutils.background.background_2d.Background2D at 0x...>]
+    >>> {color:data.background_rms_median for color, data in zip('rgb', rgb_backs)}
+    {'r': 20.566..., 'g': 32.787..., 'b': 23.820...}
 
 
     Args:
@@ -264,7 +268,10 @@ def get_rgb_background(fits_fn,
                            interpolator=interp)
 
         # Create a masked array for the background
-        backgrounds.append(np.ma.array(data=bkg.background, mask=color_data.mask))
+        if return_separate:
+            backgrounds.append(bkg)
+        else:
+            backgrounds.append(np.ma.array(data=bkg.background, mask=color_data.mask))
         logger.debug(
             f"{color} Value: {bkg.background_median:.02f} RMS: {bkg.background_rms_median:.02f}")
 


### PR DESCRIPTION
Following on #162, instead of just returned the separate masked arrays, return the actual `Background2D` object. This gives access to the RMS mesh grid and other properties of each computed background.