### PR TITLE
fpack/funpack will overwrite destination by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 * FITS Utils fixes (#173):
     * Fix docstring return types for some functions.
+* `fpack`/`funpack` and `get_solve_field` were not properly overwriting FITS files under certain conditions when an uncompressed file of the same name was present alongside the compressed version. (#175)
 
 ### Changed
 
@@ -20,6 +21,7 @@ All notable changes to this project will be documented in this file.
     * Better checking for solved file at end (via `is_celestial`).
     * Cleanup the cleanup of solve files, removing `remove_extras` option.
     * Pass `kwargs` to underlying `writeto` method for `write_fits`. Needed for, e.g. `overwrite`.
+* Changed `bin/panoptes-dev` -> `bin/panoptes-develop` for naming consistency. (#175)
 
 ### Removed
 

--- a/bin/panoptes-develop
+++ b/bin/panoptes-develop
@@ -23,5 +23,5 @@ if [[ "$PARAMS" == "up -d" ]]; then
     "${PANDIR}/panoptes-utils/bin/wait-for-it.sh" \
         localhost:8888 \
         -- \
-        docker exec -it -u panoptes dev-env jupyter notebook list | grep http | cut -d ' ' -f 1 | xargs xdg-open
+        docker exec -it -u panoptes develop-env jupyter notebook list | grep http | cut -d ' ' -f 1 | xargs xdg-open
 fi

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -165,7 +165,7 @@ def get_solve_field(fname, replace=True, overwrite=True, **kwargs):
     new_fname = fname.replace('.fits', '.new')
     if replace:
         logger.debug(f'Overwriting original {fname}')
-        shutil.move(new_fname, fname)
+        os.replace(new_fname, fname)
     else:
         fname = new_fname
 
@@ -284,7 +284,7 @@ def get_wcsinfo(fits_fname, **kwargs):
     return wcs_info
 
 
-def fpack(fits_fname, unpack=False):
+def fpack(fits_fname, unpack=False, overwrite=True):
     """Compress/Decompress a FITS file
 
     Uses `fpack` (or `funpack` if `unpack=True`) to compress a FITS file
@@ -307,6 +307,12 @@ def fpack(fits_fname, unpack=False):
         fpack = shutil.which('fpack')
         run_cmd = [fpack, '-D', '-Y', fits_fname]
         out_file = fits_fname.replace('.fits', '.fits.fz')
+
+    if os.path.exists(out_file):
+        if overwrite is False:
+            raise FileExistsError(f'Destination file already exists at location and overwrite=False')
+        else:
+            os.remove(out_file)
 
     try:
         assert fpack is not None

--- a/panoptes/utils/tests/images/test_fits_utils.py
+++ b/panoptes/utils/tests/images/test_fits_utils.py
@@ -37,6 +37,23 @@ def test_fpack(solved_fits_file):
     os.remove(copy_file)
 
 
+def test_no_overwrite_fpack(solved_fits_file):
+    new_file = solved_fits_file.replace('solved', 'solved_copy')
+    copy_file = shutil.copyfile(solved_fits_file, new_file)
+
+    uncompressed = fits_utils.funpack(copy_file)
+
+    with pytest.raises(FileExistsError):
+        _ = fits_utils.fpack(uncompressed, overwrite=False)
+
+    with pytest.raises(FileExistsError):
+        compressed = fits_utils.fpack(uncompressed)
+
+    for file in [copy_file, uncompressed, compressed]:
+        with suppress(FileNotFoundError):
+            os.remove(file)
+
+
 def test_getheader(solved_fits_file):
     header = fits_utils.getheader(solved_fits_file)
     assert isinstance(header, Header)

--- a/panoptes/utils/tests/images/test_fits_utils.py
+++ b/panoptes/utils/tests/images/test_fits_utils.py
@@ -42,6 +42,8 @@ def test_no_overwrite_fpack(solved_fits_file):
     copy_file = shutil.copyfile(solved_fits_file, new_file)
 
     uncompressed = fits_utils.funpack(copy_file)
+    # Copy file again so now the packed version still exists.
+    copy_file = shutil.copyfile(solved_fits_file, new_file)
 
     with pytest.raises(FileExistsError):
         _ = fits_utils.fpack(uncompressed, overwrite=False)

--- a/panoptes/utils/tests/images/test_fits_utils.py
+++ b/panoptes/utils/tests/images/test_fits_utils.py
@@ -1,11 +1,11 @@
 import os
-import pytest
-import subprocess
 import shutil
+import subprocess
 from contextlib import suppress
 
-from astropy.io.fits import Header
+import pytest
 from astropy import units as u
+from astropy.io.fits import Header
 
 from panoptes.utils.images import fits as fits_utils
 
@@ -41,16 +41,20 @@ def test_no_overwrite_fpack(solved_fits_file):
     new_file = solved_fits_file.replace('solved', 'solved_copy')
     copy_file = shutil.copyfile(solved_fits_file, new_file)
 
+    # Unpack the file. This removes the packed version.
     uncompressed = fits_utils.funpack(copy_file)
-    # Copy file again so now the packed version still exists.
+
+    # Copy file again so now the packed version exists alongside unpacked.
     copy_file = shutil.copyfile(solved_fits_file, new_file)
 
+    # Deny overwriting gives error.
     with pytest.raises(FileExistsError):
         _ = fits_utils.fpack(uncompressed, overwrite=False)
 
     # Default is overwrite=True.
     compressed = fits_utils.fpack(uncompressed)
 
+    # Cleanup test.
     for file in [copy_file, uncompressed, compressed]:
         with suppress(FileNotFoundError):
             os.remove(file)

--- a/panoptes/utils/tests/images/test_fits_utils.py
+++ b/panoptes/utils/tests/images/test_fits_utils.py
@@ -48,8 +48,8 @@ def test_no_overwrite_fpack(solved_fits_file):
     with pytest.raises(FileExistsError):
         _ = fits_utils.fpack(uncompressed, overwrite=False)
 
-    with pytest.raises(FileExistsError):
-        compressed = fits_utils.fpack(uncompressed)
+    # Default is overwrite=True.
+    compressed = fits_utils.fpack(uncompressed)
 
     for file in [copy_file, uncompressed, compressed]:
         with suppress(FileNotFoundError):


### PR DESCRIPTION
Sadly, this was failing silently, so the file was not overwritten but returning a True value to indicate it was. This was causing the ~~incorrect file to be saved~~ file to not be solved, which leads to the FITS headers being pulled from the old, non-solved file. These old headers were then being written to the new file.