### PR TITLE
Initial commits for some of the data access components.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,3 +18,4 @@ omit =
     panoptes/tests/*
     panoptes/utils/tests/*
     panoptes/utils/_version.py
+    panoptes/utils/data.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -18,4 +18,3 @@ omit =
     panoptes/tests/*
     panoptes/utils/tests/*
     panoptes/utils/_version.py
-    panoptes/utils/data.py

--- a/panoptes/utils/data.py
+++ b/panoptes/utils/data.py
@@ -4,6 +4,7 @@ import shutil
 import pandas as pd
 from astroplan import download_IERS_A
 from astropy.utils import data
+from google.auth.credentials import AnonymousCredentials
 from google.cloud import firestore
 
 from .logger import logger
@@ -53,7 +54,7 @@ def get_data(image_id=None, sequence_id=None, fields=None, firestore_client=None
     """
     if firestore_client is None:
         logger.debug(f'Getting new firestore client')
-        firestore_client = firestore.Client()
+        firestore_client = firestore.Client(credentials=AnonymousCredentials())
 
     # Get a FITS image from the bucket.
     if image_id is not None:

--- a/panoptes/utils/data.py
+++ b/panoptes/utils/data.py
@@ -21,27 +21,27 @@ def get_data(image_id=None, sequence_id=None, firestore_client=None):
 
     Example:
 
-            >>> # Download a specific image.
-            >>> from panoptes.utils.images import fits as fits_utils
-            >>> from panoptes.utils.data import get_data
-            >>> image_id = 'PAN001_14d3bd_20160911T101445'
-            >>> fits_file = get_data(image_id=image_id)  # doctest: +SKIP
-            >>> fits_utils.getval(fits_file, 'FIELD')  # doctest: +SKIP
-            Wasp 33
+        >>> # Download a specific image.
+        >>> from panoptes.utils.images import fits as fits_utils
+        >>> from panoptes.utils.data import get_data
+        >>> image_id = 'PAN001_14d3bd_20160911T101445'
+        >>> fits_file = get_data(image_id=image_id)  # doctest: +SKIP
+        >>> fits_utils.getval(fits_file, 'FIELD')  # doctest: +SKIP
+        Wasp 33
 
-            >>> # Download observation information
-            >>> sequence_id = 'PAN001_14d3bd_20160911T095804'
-            >>> observation = get_data(sequence_id=sequence_id) # doctest: +SKIP
-            >>> observation.describe() # doctest: +SKIP
-                      exptime    dec_mnt     moonsep  ...     ha_mnt    airmass  dec_image
-            count   10.000000  10.000000   10.000000  ...  10.000000  10.000000   3.000000
-            mean   133.150000  37.550481  121.816168  ...  20.785812   1.432349  37.551674
-            std     40.635268   0.000000    0.058508  ...   0.142363   0.043384   0.002784
-            min    120.300000  37.550481  121.734949  ...  20.538607   1.375450  37.548547
-            25%    120.300000  37.550481  121.773715  ...  20.704128   1.400616  37.550569
-            50%    120.300000  37.550481  121.812113  ...  20.796700   1.427342  37.552590
-            75%    120.300000  37.550481  121.850095  ...  20.889282   1.455701  37.553237
-            max    248.800000  37.550481  121.916972  ...  20.981754   1.510904  37.553885
+        >>> # Download observation information
+        >>> sequence_id = 'PAN001_14d3bd_20160911T095804'
+        >>> observation = get_data(sequence_id=sequence_id) # doctest: +SKIP
+        >>> observation.describe() # doctest: +SKIP
+                  exptime    dec_mnt     moonsep  ...     ha_mnt    airmass  dec_image
+        count   10.000000  10.000000   10.000000  ...  10.000000  10.000000   3.000000
+        mean   133.150000  37.550481  121.816168  ...  20.785812   1.432349  37.551674
+        std     40.635268   0.000000    0.058508  ...   0.142363   0.043384   0.002784
+        min    120.300000  37.550481  121.734949  ...  20.538607   1.375450  37.548547
+        25%    120.300000  37.550481  121.773715  ...  20.704128   1.400616  37.550569
+        50%    120.300000  37.550481  121.812113  ...  20.796700   1.427342  37.552590
+        75%    120.300000  37.550481  121.850095  ...  20.889282   1.455701  37.553237
+        max    248.800000  37.550481  121.916972  ...  20.981754   1.510904  37.553885
 
     Args:
         image_id (str|None): The id associated with an image.

--- a/panoptes/utils/data.py
+++ b/panoptes/utils/data.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-from contextlib import suppress
 
 import pandas as pd
 from astroplan import download_IERS_A
@@ -10,7 +9,7 @@ from google.cloud import firestore
 from .logger import logger
 
 
-def get_data(image_id=None, sequence_id=None, firestore_client=None):
+def get_data(image_id=None, sequence_id=None, fields=None, firestore_client=None):
     """Access PANOPTES data from the network.
 
     This function is capable of searching one type of object at a time, which is
@@ -39,6 +38,8 @@ def get_data(image_id=None, sequence_id=None, firestore_client=None):
     50%     1.427342  37.552235  37.550481  ...  121.812113  36.698786  36.712742
     75%     1.455701  37.552914  37.550481  ...  121.850095  36.704645  36.712742
     max     1.510904  37.553885  37.550481  ...  121.916972  36.706083  36.712742
+    >>> # It's also possible to request certain fields
+    >>> urls = get_data(sequence_id=sequence_id, fields=['public_url']) # doctest: +SKIP
 
     Args:
         image_id (str|None): The id associated with an image.
@@ -56,19 +57,24 @@ def get_data(image_id=None, sequence_id=None, firestore_client=None):
 
     # Get a FITS image from the bucket.
     if image_id is not None:
-        return get_image(image_id=image_id, firestore_client=firestore_client)
+        return get_image(image_id=image_id, fields=fields, firestore_client=firestore_client)
 
     # Get observation metadata from firestore.
     if sequence_id is not None:
-        return get_observation(sequence_id, firestore_client=firestore_client)
+        return get_observation(sequence_id, fields=fields, firestore_client=firestore_client)
 
 
-def get_image(image_id, firestore_client=None):
+def get_image(image_id, fields=None, firestore_client=None):
     """Downloads the image at the given path.
 
     This function by default returns a `pandas.DataFrame` to be consistent with
     the `get_observation` function however that DataFrame should only contain
     a single row. Note that it will still be a DataFrame and not a `pandas.Series`.
+
+    Args:
+        fields (list|None):  A list of fields to fetch from the database. If None,
+            returns all fields.
+        image_id (str): The id for the given image.
 
     Returns:
         `pandas.DataFrame`: DataFrame containing the image metadata.
@@ -86,26 +92,29 @@ def get_image(image_id, firestore_client=None):
     image_doc = image_doc_snapshot.to_dict()
     image_doc['image_id'] = image_doc_snapshot.id
 
-    # Remove metadata metadata.
-    remove_cols = ['received_time']
-    for field in remove_cols:
-        with suppress(KeyError):
-            del image_doc[field]
-
     # Put document into dataframe
     df = pd.DataFrame(image_doc, index=[0])
     df = df.convert_dtypes()
     df = df.reindex(sorted(df.columns), axis=1)
+
+    # Remove metadata metadata.
+    # Remove fields if only certain fields requested.
+    # TODO(wtgee) implement this filtering at the firestore level.
+    if fields is not None:
+        remove_cols = set(df.columns).difference(fields)
+        df.drop(columns=remove_cols, inplace=True)
 
     # TODO(wtgee) any data cleaning or preparation for images here.
 
     return df
 
 
-def get_observation(sequence_id, firestore_client=None):
+def get_observation(sequence_id, firestore_client=None, fields=None):
     """Get the observation metadata.
 
     Args:
+        fields (list|None):  A list of fields to fetch from the database. If None,
+            returns all fields.
         sequence_id (str): The id for the given observation.
 
     Returns:
@@ -123,14 +132,16 @@ def get_observation(sequence_id, firestore_client=None):
     df = pd.DataFrame([dict(image_id=doc.id, **doc.to_dict()) for doc in obs_query.stream()])
     df = df.convert_dtypes()
     df = df.reindex(sorted(df.columns), axis=1)
+    df.sort_values(by=['time'], inplace=True)
 
     # TODO(wtgee) any data cleaning or preparation for observations here.
 
-    # Remove the background fields at single image level.
-    remove_cols = ['background_median', 'background_rms']
-    df.drop(columns=remove_cols, inplace=True)
+    # Remove fields if only certain fields requested.
+    # TODO(wtgee) implement this filtering at the firestore level.
+    if fields is not None:
+        remove_cols = set(df.columns).difference(fields)
+        df.drop(columns=remove_cols, inplace=True)
 
-    df.sort_values(by=['time'], inplace=True)
     return df
 
 

--- a/panoptes/utils/data.py
+++ b/panoptes/utils/data.py
@@ -16,6 +16,8 @@ def get_data(image_id=None, sequence_id=None, fields=None, firestore_client=None
     This function is capable of searching one type of object at a time, which is
     specified via the respective id parameter.
 
+    #TODO(wtgee): Setup firestore emulator for testing.
+
     >>> from panoptes.utils.data import get_data
     >>> # Get image metadata as a DataFrame with one record.
     >>> image_id = 'PAN001_14d3bd_20160911T101445'

--- a/panoptes/utils/data.py
+++ b/panoptes/utils/data.py
@@ -98,7 +98,7 @@ def get_image(image_id, fields=None, firestore_client=None):
     image_doc_snapshot = image_doc_ref.get()
 
     if image_doc_snapshot is None:
-        logger.debug(f'No document found for {image_id}')
+        logger.debug(f'No document found for image_id={image_id}')
         return
 
     # Get the actual image metadata.
@@ -145,7 +145,7 @@ def get_observation(sequence_id, firestore_client=None, fields=None):
     df = pd.DataFrame([dict(image_id=doc.id, **doc.to_dict()) for doc in obs_query.stream()])
 
     if len(df) == 0:
-        logger.debug(f'No document found for {image_id}')
+        logger.debug(f'No documents found for sequence_id={sequence_id}')
         return
 
     df = df.convert_dtypes()

--- a/panoptes/utils/data.py
+++ b/panoptes/utils/data.py
@@ -19,10 +19,10 @@ def get_data(image_id=None, sequence_id=None, fields=None, firestore_client=None
     >>> # Get image metadata as a DataFrame with one record.
     >>> image_id = 'PAN001_14d3bd_20160911T101445'
     >>> image_info = get_data(image_id=image_id)  # doctest: +SKIP
-    >>> image_info
+    >>> image_info # doctest: +SKIP
         airmass  background_median  ...                      time unit_id
     0  1.421225               <NA>  ... 2016-09-11 10:14:45+00:00  PAN001
-    >>> type(image_info)
+    >>> type(image_info) # doctest: +SKIP
     pandas.core.frame.DataFrame
 
     >>> # Get all image metadata for the observation.

--- a/panoptes/utils/data.py
+++ b/panoptes/utils/data.py
@@ -18,17 +18,17 @@ def get_data(image_id=None, sequence_id=None, fields=None, firestore_client=None
     >>> from panoptes.utils.data import get_data
     >>> # Get image metadata as a DataFrame with one record.
     >>> image_id = 'PAN001_14d3bd_20160911T101445'
-    >>> image_info = get_data(image_id=image_id)  # doctest: +SKIP
-    >>> image_info # doctest: +SKIP
+    >>> image_info = get_data(image_id=image_id)
+    >>> image_info
         airmass  background_median  ...                      time unit_id
     0  1.421225               <NA>  ... 2016-09-11 10:14:45+00:00  PAN001
-    >>> type(image_info) # doctest: +SKIP
+    >>> type(image_info)
     pandas.core.frame.DataFrame
 
     >>> # Get all image metadata for the observation.
     >>> sequence_id = 'PAN001_14d3bd_20160911T095804'
-    >>> observation = get_data(sequence_id=sequence_id) # doctest: +SKIP
-    >>> observation.describe() # doctest: +SKIP
+    >>> observation = get_data(sequence_id=sequence_id)
+    >>> observation.describe()
              airmass  dec_image    dec_mnt  ...     moonsep   ra_image     ra_mnt
     count  10.000000   4.000000  10.000000  ...   10.000000   4.000000  10.000000
     mean    1.432349  37.551726  37.550481  ...  121.816168  36.698585  36.712742
@@ -39,7 +39,7 @@ def get_data(image_id=None, sequence_id=None, fields=None, firestore_client=None
     75%     1.455701  37.552914  37.550481  ...  121.850095  36.704645  36.712742
     max     1.510904  37.553885  37.550481  ...  121.916972  36.706083  36.712742
     >>> # It's also possible to request certain fields
-    >>> urls = get_data(sequence_id=sequence_id, fields=['public_url']) # doctest: +SKIP
+    >>> urls = get_data(sequence_id=sequence_id, fields=['public_url'])
 
     Args:
         image_id (str|None): The id associated with an image.

--- a/panoptes/utils/data.py
+++ b/panoptes/utils/data.py
@@ -97,6 +97,10 @@ def get_image(image_id, fields=None, firestore_client=None):
     image_doc_ref = firestore_client.document(f'images/{image_id}')
     image_doc_snapshot = image_doc_ref.get()
 
+    if image_doc_snapshot is None:
+        logger.debug(f'No document found for {image_id}')
+        return
+
     # Get the actual image metadata.
     image_doc = image_doc_snapshot.to_dict()
     image_doc['image_id'] = image_doc_snapshot.id
@@ -139,6 +143,11 @@ def get_observation(sequence_id, firestore_client=None, fields=None):
 
     # Fetch documents into a DataFrame.
     df = pd.DataFrame([dict(image_id=doc.id, **doc.to_dict()) for doc in obs_query.stream()])
+
+    if len(df) == 0:
+        logger.debug(f'No document found for {image_id}')
+        return
+
     df = df.convert_dtypes()
     df = df.reindex(sorted(df.columns), axis=1)
     df.sort_values(by=['time'], inplace=True)

--- a/panoptes/utils/data.py
+++ b/panoptes/utils/data.py
@@ -9,6 +9,8 @@ from google.cloud import firestore
 
 from .logger import logger
 
+PROJECT_ID = os.getenv('PROJECT_ID', 'panoptes-exp')
+
 
 def get_data(image_id=None, sequence_id=None, fields=None, firestore_client=None):
     """Access PANOPTES data from the network.
@@ -56,7 +58,11 @@ def get_data(image_id=None, sequence_id=None, fields=None, firestore_client=None
     """
     if firestore_client is None:
         logger.debug(f'Getting new firestore client')
-        firestore_client = firestore.Client(credentials=AnonymousCredentials())
+        firestore_client = firestore.Client(
+            database=PROJECT_ID,
+            project=PROJECT_ID,
+            credentials=AnonymousCredentials()
+        )
 
     # Get a FITS image from the bucket.
     if image_id is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,11 +17,12 @@ decorator==4.4.1          # via mocket
 fastparquet==0.3.3        # via panoptes-utils (setup.py)
 flask==1.1.1              # via panoptes-utils (setup.py)
 google-api-core[grpc]==1.16.0  # via google-cloud-bigquery, google-cloud-core, google-cloud-firestore
-google-auth==1.13.1       # via google-api-core, google-cloud-bigquery
+google-auth==1.13.1       # via google-api-core, google-cloud-bigquery, google-cloud-storage
 google-cloud-bigquery[pandas]==1.24.0  # via panoptes-utils (setup.py)
-google-cloud-core==1.3.0  # via google-cloud-bigquery, google-cloud-firestore
+google-cloud-core==1.3.0  # via google-cloud-bigquery, google-cloud-firestore, google-cloud-storage
 google-cloud-firestore==1.6.2  # via panoptes-utils (setup.py)
-google-resumable-media==0.5.0  # via google-cloud-bigquery
+google-cloud-storage==1.28.0  # via panoptes-utils (setup.py)
+google-resumable-media==0.5.0  # via google-cloud-bigquery, google-cloud-storage
 googleapis-common-protos==1.51.0  # via google-api-core
 grpcio==1.28.1            # via google-api-core
 idna==2.9                 # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,12 +16,14 @@ cycler==0.10.0            # via matplotlib
 decorator==4.4.1          # via mocket
 fastparquet==0.3.3        # via panoptes-utils (setup.py)
 flask==1.1.1              # via panoptes-utils (setup.py)
-google-api-core==1.16.0   # via google-cloud-bigquery, google-cloud-core
+google-api-core[grpc]==1.16.0  # via google-cloud-bigquery, google-cloud-core, google-cloud-firestore
 google-auth==1.13.1       # via google-api-core, google-cloud-bigquery
 google-cloud-bigquery[pandas]==1.24.0  # via panoptes-utils (setup.py)
-google-cloud-core==1.3.0  # via google-cloud-bigquery
+google-cloud-core==1.3.0  # via google-cloud-bigquery, google-cloud-firestore
+google-cloud-firestore==1.6.2  # via panoptes-utils (setup.py)
 google-resumable-media==0.5.0  # via google-cloud-bigquery
 googleapis-common-protos==1.51.0  # via google-api-core
+grpcio==1.28.1            # via google-api-core
 idna==2.9                 # via requests
 importlib-metadata==1.5.0  # via pluggy, pytest
 itsdangerous==1.1.0       # via flask
@@ -54,7 +56,7 @@ pytest-remotedata==0.3.2  # via panoptes-utils (setup.py)
 pytest==5.3.5             # via panoptes-utils (setup.py), pytest-cov, pytest-remotedata
 python-dateutil==2.8.1    # via matplotlib, pandas, panoptes-utils (setup.py)
 python-magic==0.4.15      # via mocket
-pytz==2019.3              # via astroplan, google-api-core, pandas
+pytz==2019.3              # via astroplan, google-api-core, google-cloud-firestore, pandas
 pyyaml==5.3               # via panoptes-utils (setup.py)
 pyzmq==18.1.1             # via panoptes-utils (setup.py)
 requests-oauthlib==1.3.0  # via tweepy
@@ -64,7 +66,7 @@ ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.10      # via panoptes-utils (setup.py)
 scalpl==0.3.0             # via panoptes-utils (setup.py)
 scipy==1.4.1              # via panoptes-utils (setup.py)
-six==1.14.0               # via astroplan, cycler, fastparquet, google-api-core, google-auth, google-cloud-bigquery, google-resumable-media, mocket, packaging, protobuf, pytest-remotedata, python-dateutil, thrift, tweepy
+six==1.14.0               # via astroplan, cycler, fastparquet, google-api-core, google-auth, google-cloud-bigquery, google-resumable-media, grpcio, mocket, packaging, protobuf, pytest-remotedata, python-dateutil, thrift, tweepy
 thrift==0.13.0            # via fastparquet
 tweepy==3.8.0             # via panoptes-utils (setup.py)
 urllib3==1.25.8           # via mocket, requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,9 @@ packages =
 
 [tool:pytest]
 python_files= test_*.py
-norecursedirs= scripts resources
-addopts= --doctest-modules
-doctest_optionflags= ELLIPSIS NORMALIZE_WHITESPACE ALLOW_UNICODE IGNORE_EXCEPTION_DETAIL
+norecursedirs = scripts resources
+addopts = --doctest-modules --ignore panoptes/utils/data.py
+doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE ALLOW_UNICODE IGNORE_EXCEPTION_DETAIL
 filterwarnings =
     ignore:elementwise == comparison failed:DeprecationWarning
     ignore::pytest.PytestDeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ modules = {
         'Flask',
         'fastparquet',
         'google-cloud-bigquery[pandas]',
+        'google-cloud-firestore',
         'loguru',
         'matplotlib>=3.1.3',
         'mocket',  # testing

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ modules = {
         'fastparquet',
         'google-cloud-bigquery[pandas]',
         'google-cloud-firestore',
+        'google-cloud-storage',
         'loguru',
         'matplotlib>=3.1.3',
         'mocket',  # testing


### PR DESCRIPTION
This PR creates three functions:

* `get_data` is a wrapper around the more specific functions. For now that is `get_image` and `get_observation`.
* `get_image` will download a fits image.
* `get_observation` downloads a dataframe with image metadata for all images in the observation.

This PR has a working (but limited) `get_image` and `get_observations`.

~~`get_image` currently it does a lookup on the firestore db in order to get the full path (because the `sequence_id` is not part of the `image_id`) and then uses the google client to download files.~~

~~Alternatively we could create a cloud function that hides the details of firestore (so the user doesn't need login access). Likewise, we could download via the public url and `requests` rather than use the google storage libraries.~~

`get_data` and the underlying functions will always return a DataFrame. In the case of images that is a dataframe with a single row.

Anonymous firestore access is granted if no `firestore_client` is provided.

Some data cleaning happens for each function, including sorting by time index, dtype conversions etc. Could maybe still use more.
* DataFrames have columns sorted by name and rows sorted by the `time` column.
* Data types have been auto discovered with the new `convert_dtypes`.

There is limited support for returning only certain `fields`.  Happens at the dataframe level when it should happen at the firestore level. Will get better documentation examples when it is better implemented.

See usage example in the file.

Part of #177 