### PR TITLE
More flexible solve options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Bug fixes
 
-* FITS Utils fixes (#173):
-    * Fix docstring return types for some functions.
-* `fpack`/`funpack` and `get_solve_field` were not properly overwriting FITS files under certain conditions when an uncompressed file of the same name was present alongside the compressed version. (#175)
+* FITS Utils fixes:
+    * Fix docstring return types for some functions. (#173)
+    * `fpack`/`funpack` and `get_solve_field` were not properly overwriting FITS files under 
+    certain conditions when an uncompressed file of the same name was present alongside the 
+    compressed version. (#175)
 
 ### Changed
 
@@ -21,6 +23,7 @@ All notable changes to this project will be documented in this file.
     * Better checking for solved file at end (via `is_celestial`).
     * Cleanup the cleanup of solve files, removing `remove_extras` option.
     * Pass `kwargs` to underlying `writeto` method for `write_fits`. Needed for, e.g. `overwrite`.
+    * Allow additional options to be passed to solve field functions without having to override all options. (#180)
 * Changed `bin/panoptes-dev` -> `bin/panoptes-develop` for naming consistency. (#175)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
     * `fpack`/`funpack` and `get_solve_field` were not properly overwriting FITS files under 
     certain conditions when an uncompressed file of the same name was present alongside the 
     compressed version. (#175)
+    * Properly pass `args` and `kwargs` to `astropy.io.fits.getdata`. (#180)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
     * Cleanup the cleanup of solve files, removing `remove_extras` option.
     * Pass `kwargs` to underlying `writeto` method for `write_fits`. Needed for, e.g. `overwrite`.
     * Allow additional options to be passed to solve field functions without having to override all options. (#180)
+    * Changed default options in `get_solve_field` to use `scale-low` and `scale-high` instead of `radius` (which
+    requires an `ra` and `dec`). (#180)
 * Changed `bin/panoptes-dev` -> `bin/panoptes-develop` for naming consistency. (#175)
 
 ### Removed

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -122,7 +122,7 @@ def get_solve_field(fname, replace=True, overwrite=True, **kwargs):
     >>> # Pass args and kwargs to `solve-field` program.
     >>> solve_args = ['--use-wget']
     >>> solve_kwargs = {'--pnm': './awesome.bmp'}
-    >>> solve_info = fits_utils.get_solve_field(fn, *solve_args, **solve_kwargs, skip_solved=False)
+    >>> solve_info = fits_utils.get_solve_field(fits_fn, *solve_args, **solve_kwargs, skip_solved=False)
 
     Args:
         fname ({str}): Name of FITS file to be solved.

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -166,9 +166,6 @@ def get_solve_field(fname, replace=True, overwrite=True, *args, **kwargs):
     except subprocess.TimeoutExpired:
         proc.kill()
         output, errs = proc.communicate()
-        logger.debug(f'Timeout on {fname}')
-        logger.debug(f'Output on {fname}: {output}')
-        logger.debug(f'Errors on {fname}: {errs}')
         raise error.Timeout(f'Timeout while solving: {output!r} {errs!r}')
     else:
         if proc.returncode != 0:

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -122,7 +122,7 @@ def get_solve_field(fname, replace=True, overwrite=True, **kwargs):
     >>> # Pass args and kwargs to `solve-field` program.
     >>> solve_args = ['--use-wget']
     >>> solve_kwargs = {'--pnm': './awesome.bmp'}
-    >>> solve_info = fu.get_solve_field(fn, *solve_args, **solve_kwargs, skip_solved=False)
+    >>> solve_info = fits_utils.get_solve_field(fn, *solve_args, **solve_kwargs, skip_solved=False)
 
     Args:
         fname ({str}): Name of FITS file to be solved.

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -467,7 +467,8 @@ def getdata(fn, *args, **kwargs):
     image.
 
     >>> fits_fn = getfixture('solved_fits_file')
-    >>> getdata(fits_fn)
+    >>> d0 = getdata(fits_fn)
+    >>> d0
     array([[2215, 2169, 2200, ..., 2169, 2235, 2168],
            [2123, 2191, 2133, ..., 2212, 2127, 2217],
            [2208, 2154, 2209, ..., 2159, 2233, 2187],
@@ -475,6 +476,11 @@ def getdata(fn, *args, **kwargs):
            [2120, 2201, 2120, ..., 2209, 2126, 2195],
            [2219, 2151, 2199, ..., 2173, 2214, 2166],
            [2114, 2194, 2122, ..., 2202, 2125, 2204]], dtype=uint16)
+    >>> d1, h1 = getdata(fits_fn, header=True)
+    >>> d0 == d1
+    True
+    >>> h1['FIELD']
+    'KIC 8462852'
 
     Args:
         fn (str): Path to FITS file.
@@ -484,7 +490,7 @@ def getdata(fn, *args, **kwargs):
     Returns:
         `np.ndarray`: The FITS data.
     """
-    return fits.getdata(fn)
+    return fits.getdata(fn, *args, **kwargs)
 
 
 def getheader(fn, *args, **kwargs):

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -472,7 +472,7 @@ def getdata(fn, *args, **kwargs):
            [2219, 2151, 2199, ..., 2173, 2214, 2166],
            [2114, 2194, 2122, ..., 2202, 2125, 2204]], dtype=uint16)
     >>> d1, h1 = getdata(fits_fn, header=True)
-    >>> all(d0 == d1)
+    >>> (d0 == d1).all()
     True
     >>> h1['FIELD']
     'KIC 8462852'

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -151,6 +151,9 @@ def get_solve_field(fname, replace=True, overwrite=True, *args, **kwargs):
     kwargs.setdefault('--scale-low', 10)
     kwargs.setdefault('--scale-high', 16)
     kwargs.setdefault('--scale-units', 'degwidth')
+    if overwrite:
+        args = list(args)
+        args.append('--overwrite')
 
     # Use unpacked version of file.
     was_compressed = False
@@ -160,7 +163,7 @@ def get_solve_field(fname, replace=True, overwrite=True, *args, **kwargs):
         logger.debug(f'Using {fname} for solving')
         was_compressed = True
 
-    proc = solve_field(fname, overwrite=overwrite, *args, **kwargs)
+    proc = solve_field(fname, *args, **kwargs)
     try:
         output, errs = proc.communicate(timeout=kwargs.get('timeout', 30))
     except subprocess.TimeoutExpired:

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -151,8 +151,6 @@ def get_solve_field(fname, replace=True, overwrite=True, *args, **kwargs):
     kwargs.setdefault('--scale-low', 10)
     kwargs.setdefault('--scale-high', 16)
     kwargs.setdefault('--scale-units', 'degwidth')
-    if overwrite:
-        args.append('--overwrite')
 
     # Use unpacked version of file.
     was_compressed = False
@@ -162,7 +160,7 @@ def get_solve_field(fname, replace=True, overwrite=True, *args, **kwargs):
         logger.debug(f'Using {fname} for solving')
         was_compressed = True
 
-    proc = solve_field(fname, *args, **kwargs)
+    proc = solve_field(fname, overwrite=overwrite, *args, **kwargs)
     try:
         output, errs = proc.communicate(timeout=kwargs.get('timeout', 30))
     except subprocess.TimeoutExpired:

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -166,6 +166,9 @@ def get_solve_field(fname, replace=True, overwrite=True, *args, **kwargs):
     except subprocess.TimeoutExpired:
         proc.kill()
         output, errs = proc.communicate()
+        logger.debug(f'Timeout on {fname}')
+        logger.debug(f'Output on {fname}: {output}')
+        logger.debug(f'Errors on {fname}: {errs}')
         raise error.Timeout(f'Timeout while solving: {output!r} {errs!r}')
     else:
         if proc.returncode != 0:

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -129,7 +129,8 @@ def get_solve_field(fname, replace=True, overwrite=True, **kwargs):
         replace (bool, optional): Saves the WCS back to the original file,
             otherwise output base filename with `.new` extension. Default True.
         overwrite (bool, optional): Clobber file, default True. Required if `replace=True`.
-        **kwargs ({dict}): Options to pass to `solve_field`.
+        **args ({dict}): Options to pass to `solve_field` should start with `--`.
+        **kwargs ({dict}): Options to pass to `solve_field` should start with `--`.
 
     Returns:
         dict: Keyword information from the solved field.
@@ -152,8 +153,10 @@ def get_solve_field(fname, replace=True, overwrite=True, **kwargs):
         return out_dict
 
     # Set a default radius of 15
-    kwargs.setdefault('radius', 15)
-    kwargs.setdefault('overwrite', overwrite)
+    kwargs.setdefault('--scale-low', 10)
+    kwargs.setdefault('--scale-high', 16)
+    kwargs.setdefault('--scale-units', 'degwidth')
+    kwargs.setdefault('--overwrite', overwrite)
 
     # Use unpacked version of file.
     was_compressed = False
@@ -170,8 +173,8 @@ def get_solve_field(fname, replace=True, overwrite=True, **kwargs):
         proc.kill()
         output, errs = proc.communicate()
         logger.debug(f'Timeout on {fname}')
-        logger.debug(f'Output on {fname}: {output}')
-        logger.debug(f'Errors on {fname}: {errs}')
+        logger.debug(f'Output on {fname}: {output.decode()}')
+        logger.debug(f'Errors on {fname}: {errs.decode()}')
         raise error.Timeout(f'Timeout while solving: {output!r} {errs!r}')
     else:
         if proc.returncode != 0:

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -472,7 +472,7 @@ def getdata(fn, *args, **kwargs):
            [2219, 2151, 2199, ..., 2173, 2214, 2166],
            [2114, 2194, 2122, ..., 2202, 2125, 2204]], dtype=uint16)
     >>> d1, h1 = getdata(fits_fn, header=True)
-    >>> d0 == d1
+    >>> all(d0 == d1)
     True
     >>> h1['FIELD']
     'KIC 8462852'

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -166,9 +166,6 @@ def get_solve_field(fname, replace=True, overwrite=True, *args, **kwargs):
     except subprocess.TimeoutExpired:
         proc.kill()
         output, errs = proc.communicate()
-        logger.debug(f'Timeout on {fname}')
-        logger.debug(f'Output on {fname}: {output.decode()}')
-        logger.debug(f'Errors on {fname}: {errs.decode()}')
         raise error.Timeout(f'Timeout while solving: {output!r} {errs!r}')
     else:
         if proc.returncode != 0:

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -50,11 +50,6 @@ def solve_field(fname, timeout=15, solve_opts=None, *args, **kwargs):
             '--no-plots',
         ]
 
-        if kwargs.get('overwrite', False):
-            options.append('--overwrite')
-        if kwargs.get('skip_solved', False):
-            options.append('--skip-solved')
-
         if 'ra' in kwargs:
             options.append('--ra')
             options.append(str(kwargs.get('ra')))
@@ -91,7 +86,7 @@ def solve_field(fname, timeout=15, solve_opts=None, *args, **kwargs):
     return proc
 
 
-def get_solve_field(fname, replace=True, overwrite=True, **kwargs):
+def get_solve_field(fname, replace=True, overwrite=True, *args, **kwargs):
     """Convenience function to wait for `solve_field` to finish.
 
     This function merely passes the `fname` of the image to be solved along to `solve_field`,
@@ -156,7 +151,8 @@ def get_solve_field(fname, replace=True, overwrite=True, **kwargs):
     kwargs.setdefault('--scale-low', 10)
     kwargs.setdefault('--scale-high', 16)
     kwargs.setdefault('--scale-units', 'degwidth')
-    kwargs.setdefault('--overwrite', overwrite)
+    if overwrite:
+        args.append('--overwrite')
 
     # Use unpacked version of file.
     was_compressed = False
@@ -166,7 +162,7 @@ def get_solve_field(fname, replace=True, overwrite=True, **kwargs):
         logger.debug(f'Using {fname} for solving')
         was_compressed = True
 
-    proc = solve_field(fname, **kwargs)
+    proc = solve_field(fname, *args, **kwargs)
     try:
         output, errs = proc.communicate(timeout=kwargs.get('timeout', 30))
     except subprocess.TimeoutExpired:

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -148,9 +148,6 @@ def get_solve_field(fname, replace=True, overwrite=True, *args, **kwargs):
         return out_dict
 
     # Set a default radius of 15
-    kwargs.setdefault('--scale-low', 10)
-    kwargs.setdefault('--scale-high', 16)
-    kwargs.setdefault('--scale-units', 'degwidth')
     if overwrite:
         args = list(args)
         args.append('--overwrite')

--- a/panoptes/utils/images/fits.py
+++ b/panoptes/utils/images/fits.py
@@ -66,7 +66,7 @@ def solve_field(fname, timeout=15, solve_opts=None, *args, **kwargs):
             options.append(str(kwargs.get('radius')))
 
     # Gather all the kwargs that start with `--` and are not already present.
-    logger.debug(f'Adding args: {kwargs!r}')
+    logger.debug(f'Adding args: {args!r}')
     options.extend([opt
                     for opt
                     in args


### PR DESCRIPTION
* Fix a usage problem where you either had to pass all possible desired options or just accept most of the defaults. 
* Changes default options in `get_solve_field` to use `scale-low` and ` scale-high` instead of `radius` (which requires an `ra` and `dec`).
* Fixes bug where `args` and `kwargs` weren't being properly passed in `getdata`.

This PR fixes so that you can pass `args` and `kwargs` to `solve-field` and they will be added to the list of default options.  

These currently will **not** override the defaults, which would be desirable, but merely allow you to specify additional options in addition to the default.
