### PR TITLE
Image processing tools and solver updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.dev14]
 
+
 ### Added
 
 * Add snappy decompression for parquet; `pyarrow` instead of `fastparquet` (#193)
 * Password-less sudo for panoptes user on dev docker image (#193)
 * `get_metadata` has an optional progress bar. (#194)
+* Add `bayer.get_stamp_slice` for getting a stamp slice while respecting the superpixel. This was removed awhile ago and has been re-added and improved. (#196)
 
 ### Bug fixes
 
 * Fix time-based search (#193)
+
+### Changed
+
+* **Breaking** Only support getting stars directly from the WCS, not the footprint. (#194)
+  * `get_stars_from_footprint` -> `get_stars_from_wcs`
+  * Better logging
+  * Consistent column names for dtypes
+  * Vmag bin comes from sql.
+  * Allow for different RA/Dec column names.
+  * Better catalog match function.
+* `sextractor` param changes. (#194)
 
 ## [0.2.13] - 2020-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to this project will be documented in this file.
 * Password-less sudo for panoptes user on dev docker image (#193)
 * `get_metadata` has an optional progress bar. (#194)
 * Add `bayer.get_stamp_slice` for getting a stamp slice while respecting the superpixel. This was removed awhile ago and has been re-added and improved. (#196)
+  * Adjusting the offsets so the center pixel is always:
+    
+    ```
+       G2 B
+       R  G1
+    ```
 
 ### Bug fixes
 

--- a/panoptes/utils/data/metadata.py
+++ b/panoptes/utils/data/metadata.py
@@ -130,13 +130,13 @@ def search_observations(
     PAN001   Andromeda Galaxy     378
              HAT-P-19             148
              TESS_SEC17_CAM02    9949
-    PAN012   Andromeda Galaxy      40
+    PAN012   Andromeda Galaxy      70
              HAT-P-16 b           268
-             TESS_SEC17_CAM02     247
+             TESS_SEC17_CAM02    1983
     PAN018   TESS_SEC17_CAM02     244
     Name: num_images, dtype: Int64
     >>> print('Total minutes exposure:', search_results.total_minutes_exptime.sum())
-    Total minutes exposure: 16844.16
+    Total minutes exposure: 20376.83
 
     Args:
         ra (float|None): The RA position in degrees of the center of search.

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -203,44 +203,81 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
     >>> superpixel
     array([['G2', 'B'],
            ['R', 'G1']], dtype='<U2')
-    >>> # Tile it into a 3x3 grid of super-pixels, i.e. a 6x6 stamp.
-    >>> stamp0 = np.tile(superpixel, (3, 3))
+    >>> # Tile it into a 5x5 grid of super-pixels, i.e. a 10x10 stamp.
+    >>> stamp0 = np.tile(superpixel, (5, 5))
     >>> stamp0
+    array([['G2', 'B', 'G2', 'B', 'G2', 'B', 'G2', 'B', 'G2', 'B'],
+           ['R', 'G1', 'R', 'G1', 'R', 'G1', 'R', 'G1', 'R', 'G1'],
+           ['G2', 'B', 'G2', 'B', 'G2', 'B', 'G2', 'B', 'G2', 'B'],
+           ['R', 'G1', 'R', 'G1', 'R', 'G1', 'R', 'G1', 'R', 'G1'],
+           ['G2', 'B', 'G2', 'B', 'G2', 'B', 'G2', 'B', 'G2', 'B'],
+           ['R', 'G1', 'R', 'G1', 'R', 'G1', 'R', 'G1', 'R', 'G1'],
+           ['G2', 'B', 'G2', 'B', 'G2', 'B', 'G2', 'B', 'G2', 'B'],
+           ['R', 'G1', 'R', 'G1', 'R', 'G1', 'R', 'G1', 'R', 'G1'],
+           ['G2', 'B', 'G2', 'B', 'G2', 'B', 'G2', 'B', 'G2', 'B'],
+           ['R', 'G1', 'R', 'G1', 'R', 'G1', 'R', 'G1', 'R', 'G1']],
+          dtype='<U2')
+    >>> stamp1 = np.arange(100).reshape(5, 5)
+    >>> stamp1
+    array([[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9],
+           [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+           [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+           [30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
+           [40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
+           [50, 51, 52, 53, 54, 55, 56, 57, 58, 59],
+           [60, 61, 62, 63, 64, 65, 66, 67, 68, 69],
+           [70, 71, 72, 73, 74, 75, 76, 77, 78, 79],
+           [80, 81, 82, 83, 84, 85, 86, 87, 88, 89],
+           [90, 91, 92, 93, 94, 95, 96, 97, 98, 99]])
+    >>> x = 7
+    >>> y = 5
+    >>> pixel_index = (y, x)  # y=rows, x=columns
+    >>> stamp0[pixel_index]
+    'G1'
+    >>> stamp1[pixel_index]
+    57
+    >>> slice0 = bayer.get_stamp_slice(*pixel_index, stamp_size=(6, 6))
+    >>> slice0
+    (slice(2, 8, None), slice(4, 10, None))
+    >>> stamp0[slice0]
     array([['G2', 'B', 'G2', 'B', 'G2', 'B'],
            ['R', 'G1', 'R', 'G1', 'R', 'G1'],
            ['G2', 'B', 'G2', 'B', 'G2', 'B'],
            ['R', 'G1', 'R', 'G1', 'R', 'G1'],
            ['G2', 'B', 'G2', 'B', 'G2', 'B'],
            ['R', 'G1', 'R', 'G1', 'R', 'G1']], dtype='<U2')
-    >>> stamp1 = np.arange(36).reshape(6, 6)
-    >>> stamp1
-    array([[ 0,  1,  2,  3,  4,  5],
-           [ 6,  7,  8,  9, 10, 11],
-           [12, 13, 14, 15, 16, 17],
-           [18, 19, 20, 21, 22, 23],
-           [24, 25, 26, 27, 28, 29],
-           [30, 31, 32, 33, 34, 35]])
-    >>> pixel_index = (3, 3)
-    >>> stamp0[pixel_index]
-    'G1'
-    >>> stamp1[pixel_index]
-    21
-    >>> slice0 = bayer.get_stamp_slice(*pixel_index, stamp_size=(4, 4), ignore_superpixel=True)
-    >>> slice0
-    (slice(1, 5, None), slice(1, 5, None))
-    >>> stamp0[slice0]
-    array([['G1', 'R', 'G1', 'R'],
-           ['B', 'G2', 'B', 'G2'],
-           ['G1', 'R', 'G1', 'R'],
-           ['B', 'G2', 'B', 'G2']], dtype='<U2')
     >>> stamp1[slice0]
-    array([[ 7,  8,  9, 10],
-           [13, 14, 15, 16],
-           [19, 20, 21, 22],
-           [25, 26, 27, 28]])
+    array([[24, 25, 26, 27, 28, 29],
+           [34, 35, 36, 37, 38, 39],
+           [44, 45, 46, 47, 48, 49],
+           [54, 55, 56, 57, 58, 59],
+           [64, 65, 66, 67, 68, 69],
+           [74, 75, 76, 77, 78, 79]])
 
-    Notice that the resulting stamp has a super-pixel in the center but is not bordered by a complete super-pixel.
-    Usually we would always want a full superpixel border, so `ignore_superpixel` defaults to `False`.
+    The original index had a value of `57`, which is within the center superpixel.
+
+    Notice that the resulting stamp has a super-pixel in the center and is bordered on all sides by a complete
+    superpixel. This is required by default and an invalid size
+
+    We can use `ignore_superpixel=True` to get an odd-sized stamp.
+
+    >>> slice1 = bayer.get_stamp_slice(x, y, stamp_size=(5, 5), ignore_superpixel=True)
+    >>> slice0
+    (slice(3, 8, None), slice(5, 10, None))
+    >>> stamp0[slice1]
+    array([['G1', 'R', 'G1', 'R', 'G1'],
+           ['B', 'G2', 'B', 'G2', 'B'],
+           ['G1', 'R', 'G1', 'R', 'G1'],
+           ['B', 'G2', 'B', 'G2', 'B'],
+           ['G1', 'R', 'G1', 'R', 'G1']], dtype='<U2')
+    >>> stamp1[slice1]
+    array([[35, 36, 37, 38, 39],
+           [45, 46, 47, 48, 49],
+           [55, 56, 57, 58, 59],
+           [65, 66, 67, 68, 69],
+           [75, 76, 77, 78, 79]])
+
+    This puts the requested pixel in the center but does not offer any guarantees about the RGGB pattern.
 
     Args:
         x (float): X pixel position.

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -311,27 +311,20 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
     y_min = int(y - y_half)
     y_max = int(y + y_half)
 
-    # Alter the bounds depending on identified center pixel
-    if color == 'B':
-        x_min -= 1
-        x_max -= 1
-        y_min -= 0
-        y_max -= 0
-    elif color == 'G1':
-        x_min -= 0
-        x_max -= 0
-        y_min -= 0
-        y_max -= 0
+    # Alter the bounds depending on identified center pixel so we always center superpixel have:
+    #   G2 B
+    #   R  G1
+    if color == 'R':
+        x_min += 1
+        x_max += 1
     elif color == 'G2':
-        x_min -= 0
-        x_max -= 0
-        y_min -= 0
-        y_max -= 0
-    elif color == 'R':
-        x_min -= 0
-        x_max -= 0
-        y_min -= 1
-        y_max -= 1
+        x_min += 1
+        x_max += 1
+        y_min += 1
+        y_max += 1
+    elif color == 'B':
+        y_min += 1
+        y_max += 1
 
     # if stamp_size is odd add extra
     if stamp_size[0] % 2 == 1:

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -262,7 +262,7 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
     We can use `ignore_superpixel=True` to get an odd-sized stamp.
 
     >>> slice1 = bayer.get_stamp_slice(x, y, stamp_size=(5, 5), ignore_superpixel=True)
-    >>> slice0
+    >>> slice1
     (slice(3, 8, None), slice(5, 10, None))
     >>> stamp0[slice1]
     array([['G1', 'R', 'G1', 'R', 'G1'],

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -291,7 +291,7 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
     if not ignore_superpixel:
         for side_length in stamp_size:
             side_length -= 2  # Subtract center superpixel
-            if int(side_length / 2) % 2 != 0:
+            if side_length / 2 % 2 != 0:
                 raise RuntimeError(f"Invalid slice size: {side_length + 2} "
                                    f"Slice must have even number of pixels on each side"
                                    f"of center superpixel. i.e. 6, 10, 14, 18...")

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -218,11 +218,11 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
         x_max -= 1
         y_min -= 0
         y_max -= 0
-    # elif color == 'G1':
-    #     x_min -= 1
-    #     x_max -= 1
-    #     y_min -= 1
-    #     y_max -= 1
+    elif color == 'G1':
+        x_min -= 0
+        x_max -= 0
+        y_min -= 0
+        y_max -= 0
     elif color == 'G2':
         x_min -= 0
         x_max -= 0

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -180,6 +180,7 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
 
     Example:
 
+        >>> from panoptes.utils.images import bayer
         >>> # Grab the lower-left superpixel
         >>> bayer.get_stamp_slice(2, 2, stamp_size=(4, 4), ignore_superpixel=True)
         >>> # If we don't ignore the superpixel than it will raise an exception

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -178,6 +178,19 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
     but make sure the first position corresponds to a red-pixel. This means that
     x,y will not necessarily be at the center of the resulting stamp.
 
+    Example:
+
+        >>> # Grab the lower-left superpixel
+        >>> bayer.get_stamp_slice(2, 2, stamp_size=(4, 4), ignore_superpixel=True)
+        >>> # If we don't ignore the superpixel than it will raise an exception
+        >>> bayer.get_stamp_slice(2, 2, stamp_size=(4, 4), ignore_superpixel=False)
+        ---------------------------------------------------------------------------
+        RuntimeError                              Traceback (most recent call last)
+        ...
+        RuntimeError: Invalid slice size: 4 Slice must have even number of pixels on each sideof center superpixel...
+        >>> bayer.get_stamp_slice(310, 199)
+        (slice(191, 205, None), slice(303, 317, None))
+
     Args:
         x (float): X pixel position.
         y (float): Y pixel position.
@@ -191,11 +204,9 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
         for side_length in stamp_size:
             side_length -= 2  # Subtract center superpixel
             if int(side_length / 2) % 2 != 0:
-                logger.warning("Invalid slice size: ", side_length + 2,
-                               " Slice must have even number of pixels on each side of",
-                               " the center superpixel.",
-                               "i.e. 6, 10, 14, 18...")
-                return
+                raise RuntimeError(f"Invalid slice size: {side_length + 2} "
+                                   f"Slice must have even number of pixels on each side"
+                                   f"of center superpixel. i.e. 6, 10, 14, 18...")
 
     # Pixels have nasty 0.5 rounding issues
     x = Decimal(float(x)).to_integral()

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -236,7 +236,7 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
     'G1'
     >>> stamp1[pixel_index]
     57
-    >>> slice0 = bayer.get_stamp_slice(*pixel_index, stamp_size=(6, 6))
+    >>> slice0 = bayer.get_stamp_slice(x, y, stamp_size=(6, 6))
     >>> slice0
     (slice(2, 8, None), slice(4, 10, None))
     >>> stamp0[slice0]

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -186,9 +186,8 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
         (slice(0, 4, None), slice(0, 4, None))
         >>> # If we don't ignore the superpixel than it will raise an exception
         >>> bayer.get_stamp_slice(2, 2, stamp_size=(4, 4), ignore_superpixel=False)
-        ---------------------------------------------------------------------------
-        RuntimeError                              Traceback (most recent call last)
-        ...
+        Traceback (most recent call last)
+         ...
         RuntimeError: Invalid slice size: 4 Slice must have even number of pixels on each sideof center superpixel...
         >>> bayer.get_stamp_slice(310, 199)
         (slice(191, 205, None), slice(303, 317, None))

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -213,6 +213,7 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
            ['G2', 'B', 'G2', 'B', 'G2', 'B'],
            ['R', 'G1', 'R', 'G1', 'R', 'G1']], dtype='<U2')
     >>> stamp1 = np.arange(36).reshape(6, 6)
+    >>> stamp1
     array([[ 0,  1,  2,  3,  4,  5],
            [ 6,  7,  8,  9, 10, 11],
            [12, 13, 14, 15, 16, 17],

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -183,6 +183,7 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
         >>> from panoptes.utils.images import bayer
         >>> # Grab the lower-left superpixel
         >>> bayer.get_stamp_slice(2, 2, stamp_size=(4, 4), ignore_superpixel=True)
+        (slice(0, 4, None), slice(0, 4, None))
         >>> # If we don't ignore the superpixel than it will raise an exception
         >>> bayer.get_stamp_slice(2, 2, stamp_size=(4, 4), ignore_superpixel=False)
         ---------------------------------------------------------------------------

--- a/panoptes/utils/images/bayer.py
+++ b/panoptes/utils/images/bayer.py
@@ -217,7 +217,7 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
            ['G2', 'B', 'G2', 'B', 'G2', 'B', 'G2', 'B', 'G2', 'B'],
            ['R', 'G1', 'R', 'G1', 'R', 'G1', 'R', 'G1', 'R', 'G1']],
           dtype='<U2')
-    >>> stamp1 = np.arange(100).reshape(5, 5)
+    >>> stamp1 = np.arange(100).reshape(10, 10)
     >>> stamp1
     array([[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9],
            [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],

--- a/panoptes/utils/stars.py
+++ b/panoptes/utils/stars.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+from tempfile import TemporaryDirectory
 
 from google.cloud import bigquery
 from google.auth.credentials import AnonymousCredentials
@@ -21,41 +22,35 @@ def _get_bq_client(project_id='panoptes-exp', credentials=AnonymousCredentials()
     return bq_client
 
 
-def get_stars_from_footprint(wcs_or_footprint, **kwargs):
+def get_stars_from_wcs(wcs, origin=1, **kwargs):
     """Lookup star information from WCS footprint.
 
     Generates the correct layout for an SQL `POLYGON` that can be passed to
     `get_stars`.
 
     Args:
-        wcs_or_footprint (`astropy.wcs.WCS` or array): Either the WCS or the output from `calc_footprint`.
+        wcs (`astropy.wcs.WCS` or array): A valid (i.e. `wcs.is_celestial`) World Coordinate System object.
+        origin (int): The origin for the WCS. See `all_world2pix`. Default 1.
         **kwargs: Optional keywords to pass to `get_stars`.
 
     """
-    wcs = None
-    if isinstance(wcs_or_footprint, WCS):
-        wcs = wcs_or_footprint
-        wcs_footprint = wcs_or_footprint.calc_footprint()
-    else:
-        wcs_footprint = wcs_or_footprint
-
-    wcs_footprint = list(wcs_footprint)
-    logger.debug(f'Looking up catalog stars for WCS: {wcs_or_footprint}')
+    wcs_footprint = wcs.calc_footprint().tolist()
+    logger.debug(f'Looking up catalog stars for WCS: {wcs_footprint}')
     # Add the first entry to the end to complete polygon
     wcs_footprint.append(wcs_footprint[0])
 
     poly = ','.join([f'{c[0]:.05} {c[1]:.05f}' for c in wcs_footprint])
 
+    logger.debug(f'Using poly={poly} for get_stars')
     catalog_stars = get_stars(shape=poly, **kwargs)
 
-    # Get the XY positions via the WCS
-    if wcs is not None:
-        catalog_coords = catalog_stars[['catalog_ra', 'catalog_dec']]
-        catalog_xy = wcs.all_world2pix(catalog_coords, 1)
-        catalog_stars['x'] = catalog_xy.T[0]
-        catalog_stars['y'] = catalog_xy.T[1]
-        catalog_stars['x_int'] = catalog_stars.x.astype(int)
-        catalog_stars['y_int'] = catalog_stars.y.astype(int)
+    # Get the XY positions via the WCS if we have one.
+    catalog_coords = catalog_stars[['catalog_ra', 'catalog_dec']]
+    catalog_xy = wcs.all_world2pix(catalog_coords, origin, ra_dec_order=True)
+    catalog_stars['catalog_x'] = catalog_xy.T[0]
+    catalog_stars['catalog_y'] = catalog_xy.T[1]
+    catalog_stars['catalog_x_int'] = catalog_stars.catalog_x.astype(int)
+    catalog_stars['catalog_y_int'] = catalog_stars.catalog_y.astype(int)
 
     return catalog_stars
 
@@ -90,6 +85,7 @@ def get_stars(
         ra as catalog_ra,
         dec as catalog_dec,
         vmag as catalog_vmag,
+        vmag_partition as catalog_vmag_bin,
         e_vmag as catalog_vmag_err
     FROM catalog.pic
     WHERE
@@ -115,6 +111,7 @@ def lookup_point_sources(fits_file,
                          catalog_match=False,
                          method='sextractor',
                          force_new=False,
+                         wcs=None,
                          **kwargs
                          ):
     """Extract point sources from image.
@@ -171,6 +168,7 @@ def lookup_point_sources(fits_file,
         fits_file (str, optional): Path to FITS file to search for stars.
         catalog_match (bool, optional): If `get_catalog_match` should be called after looking up sources. Default False. If True, the `args` and `kwargs` will be passed to `get_catalog_match`.
         method (str, optional): Method for looking up sources, default (and currently only) is `sextractor`.
+        wcs (`astropy.wcs.WCS`|None): A WCS file to use. Default is `None`, in which the WCS comes from the `fits_file`
         force_new (bool, optional): Force a new catalog to be created,
             defaults to False.
         **kwargs: Passed to `get_catalog_match` when `catalog_match=True`.
@@ -183,7 +181,8 @@ def lookup_point_sources(fits_file,
 
     """
     if catalog_match:
-        wcs = fits_utils.getwcs(fits_file)
+        if wcs is None:
+            wcs = fits_utils.getwcs(fits_file)
         assert wcs is not None and wcs.is_celestial, logger.warning("Need a valid WCS")
 
     logger.debug(f"Looking up sources for {fits_file}")
@@ -214,11 +213,10 @@ def lookup_point_sources(fits_file,
 
 def get_catalog_match(point_sources,
                       wcs,
-                      vmag_min=4,
-                      vmag_max=17,
                       max_separation_arcsec=None,
                       return_unmatched=False,
-                      origin=1,
+                      ra_column='sextractor_ra',
+                      dec_column='sextractor_dec',
                       **kwargs):
     """Match the point source positions to the catalog.
 
@@ -249,6 +247,8 @@ def get_catalog_match(point_sources,
         * catalog_vmag_err
         * catalog_x
         * catalog_y
+        * catalog_x_int
+        * catalog_y_int
 
     Note:
 
@@ -283,28 +283,21 @@ def get_catalog_match(point_sources,
             to be matched. This usually comes from the output of `lookup_point_sources`
             but could be done manually.
         wcs (`astropy.wcs.WCS`): The WCS instance.
+        ra_column (str): The column name to use for the RA coordinates, default `sextractor_ra`.
+        dec_column (str): The column name to use for the Dec coordinates, default `sextractor_dec`.
         origin (int, optional): The origin for catalog matching, either 0 or 1 (default).
         max_separation_arcsec (float|None, optional): If not None, sources more
             than this many arcsecs from catalog will be filtered.
         return_unmatched (bool, optional): If all results from catalog should be
             returned, not just those with a positive match.
-        **kwargs: Unused.
+        **kwargs: Extra options are passed to `get_stars_from_wcs`, which passes them ultimately to `get_stars`.
 
     """
     assert point_sources is not None
-    logger.debug(f'Doing catalog match for wcs={wcs!r}')
-
-    # Get coords from detected point sources
-    stars_coords = SkyCoord(
-        ra=point_sources['sextractor_ra'].values * u.deg,
-        dec=point_sources['sextractor_dec'].values * u.deg
-    )
+    logger.debug(f'Doing catalog match for wcs={wcs.wcs.crval!r}')
 
     # Lookup stars in catalog
-    catalog_stars = get_stars_from_footprint(
-        wcs.calc_footprint(),
-        **kwargs
-    )
+    catalog_stars = get_stars_from_wcs(wcs, **kwargs)
     if catalog_stars is None:
         logger.debug('No catalog matches, returning table without ids')
         return point_sources
@@ -315,22 +308,19 @@ def get_catalog_match(point_sources,
         dec=catalog_stars['catalog_dec'] * u.deg
     )
 
-    # Do catalog matching
-    logger.debug(f'Matching catalog')
-    idx, d2d, d3d = match_coordinates_sky(stars_coords, catalog_coords)
-    logger.debug(f'Got {len(idx)} matched sources (includes duplicates)')
+    # Get coords from detected point sources
+    stars_coords = SkyCoord(
+        ra=point_sources[ra_column].values * u.deg,
+        dec=point_sources[dec_column].values * u.deg
+    )
 
-    # Get the xy pixel coordinates for all sources according to WCS.
-    xs, ys = wcs.all_world2pix(catalog_stars.catalog_ra,
-                               catalog_stars.catalog_dec,
-                               origin,
-                               ra_dec_order=True)
-    catalog_stars['catalog_x'] = xs
-    catalog_stars['catalog_y'] = ys
+    # Do catalog matching
+    logger.debug(f'Matching {len(catalog_coords)} catalog stars to {len(stars_coords)} detected stars {wcs.wcs.crval}')
+    idx, d2d, d3d = match_coordinates_sky(stars_coords, catalog_coords)
+    logger.debug(f'Got {len(idx)} matched sources (includes duplicates) for wcs={wcs.wcs.crval!r}')
 
     # Add the matches and their separation.
-    matches = catalog_stars.iloc[idx]
-    point_sources = point_sources.join(matches.reset_index(drop=True))
+    point_sources = point_sources.join(catalog_stars.iloc[idx].reset_index(drop=True))
     point_sources['catalog_sep_arcsec'] = d2d.to(u.arcsec).value
 
     # All point sources so far are matched.
@@ -346,6 +336,7 @@ def get_catalog_match(point_sources,
 
     # Sources that didn't match.
     if return_unmatched:
+        logger.debug(f'Adding unmatched sources to table for wcs={wcs.wcs.crval!r}')
         unmatched = catalog_stars.iloc[catalog_stars.index.difference(idx)].copy()
         unmatched['status'] = 'unmatched'
         point_sources = point_sources.append(unmatched)
@@ -353,17 +344,22 @@ def get_catalog_match(point_sources,
     # Correct some dtypes.
     point_sources.status = point_sources.status.astype('category')
 
+    logger.debug(f'Point sources: {len(point_sources)} for wcs={wcs.wcs.crval!r}')
+
     # Remove catalog matches that are too far away.
     if max_separation_arcsec is not None:
         logger.debug(f'Removing matches > {max_separation_arcsec} arcsec from catalog.')
         point_sources = point_sources.query('catalog_sep_arcsec <= @max_separation_arcsec')
 
+    logger.debug(f'Returning point sources: {len(point_sources)} for wcs={wcs.wcs.crval!r}')
     return point_sources
 
 
 def _lookup_via_sextractor(fits_file,
                            sextractor_params=None,
                            trim_size=10,
+                           force_new=False,
+                           img_dimensions=(3476, 5208),
                            *args, **kwargs):
     # Write the sextractor catalog to a file
     base_dir = os.path.dirname(fits_file)
@@ -380,7 +376,7 @@ def _lookup_via_sextractor(fits_file,
 
     logger.debug("Point source catalog: {}".format(source_file))
 
-    if not os.path.exists(source_file) or kwargs.get('force_new', False):
+    if not os.path.exists(source_file) or force_new:
         logger.debug("No catalog found, building from sextractor")
         # Build catalog of point sources
         sextractor = shutil.which('sextractor')
@@ -419,22 +415,24 @@ def _lookup_via_sextractor(fits_file,
 
     # Filter point sources near edge
     # w, h = data[0].shape
-    w, h = (3476, 5208)
-
     logger.debug('Trimming sources near edge')
+    w, h = img_dimensions
     top = point_sources['y'] > trim_size
     bottom = point_sources['y'] < w - trim_size
     left = point_sources['x'] > trim_size
     right = point_sources['x'] < h - trim_size
 
+    # Do the trim an convert to pandas.
     point_sources = point_sources[top & bottom & right & left].to_pandas()
+
+    # Add column names.
     point_sources.columns = [
         'sextractor_ra',
         'sextractor_dec',
+        'sextractor_x_int',
+        'sextractor_y_int',
         'sextractor_x',
         'sextractor_y',
-        'sextractor_x_image',
-        'sextractor_y_image',
         'sextractor_ellipticity',
         'sextractor_theta_image',
         'sextractor_flux_best',
@@ -449,4 +447,4 @@ def _lookup_via_sextractor(fits_file,
     ]
 
     logger.debug(f'Returning {len(point_sources)} sources from sextractor')
-    return point_sources
+    return point_sources.convert_dtypes()

--- a/panoptes/utils/stars.py
+++ b/panoptes/utils/stars.py
@@ -205,7 +205,7 @@ def lookup_point_sources(fits_file,
             point_sources = get_catalog_match(point_sources, wcs, **kwargs)
             logger.debug(f'Done with catalog match for {fits_file}')
         except Exception as e:
-Typ            logger.error(f'Error in catalog match, returning unmatched results: {e!r} {fits_file}')
+            logger.error(f'Error in catalog match, returning unmatched results: {e!r} {fits_file}')
 
     logger.debug(f'Point sources: {len(point_sources)} {fits_file}')
     return point_sources

--- a/panoptes/utils/stars.py
+++ b/panoptes/utils/stars.py
@@ -205,7 +205,7 @@ def lookup_point_sources(fits_file,
             point_sources = get_catalog_match(point_sources, wcs, **kwargs)
             logger.debug(f'Done with catalog match for {fits_file}')
         except Exception as e:
-            logger.error(f'Error in catalog match, returning unmathed results: {e!r} {fits_file}')
+Typ            logger.error(f'Error in catalog match, returning unmatched results: {e!r} {fits_file}')
 
     logger.debug(f'Point sources: {len(point_sources)} {fits_file}')
     return point_sources

--- a/panoptes/utils/tests/images/test_bayer.py
+++ b/panoptes/utils/tests/images/test_bayer.py
@@ -115,6 +115,10 @@ def test_get_stamp_slice_fail():
     with pytest.raises(RuntimeError):
         bayer.get_stamp_slice(512, 514, stamp_size=(15, 15))
 
+    # Unless we use `ignore_superpixel`
+    s0 = bayer.get_stamp_slice(512, 514, stamp_size=(15, 15), ignore_superpixel=True)
+    assert s0 == (slice(508, 523, None), slice(506, 521, None))
+
     # Nothing where (i-2) % 4 != 0
     with pytest.raises(RuntimeError):
         bayer.get_stamp_slice(512, 514, stamp_size=(12, 12))

--- a/panoptes/utils/tests/images/test_bayer.py
+++ b/panoptes/utils/tests/images/test_bayer.py
@@ -83,3 +83,40 @@ def test_get_pixel_color():
     assert bayer.get_pixel_color(1.9, 1) == 'G1'
     assert bayer.get_pixel_color(2, 2.5) == 'G2'
     assert bayer.get_pixel_color(1.5, 2) == 'B'
+
+
+def test_get_stamp_slice():
+    superpixel = np.array(['G2', 'B', 'R', 'G1']).reshape(2, 2)
+    d0 = np.tile(superpixel, (5, 5))
+    d1 = np.arange(100).reshape(10, 10)
+
+    positions = [
+        (6, 4),
+        (6, 5),
+        (7, 4),
+        (7, 5),
+    ]
+
+    centers = {d0[y, x]: d1[y, x] for x, y in positions}
+    assert centers == {'G2': 46, 'R': 56, 'B': 47, 'G1': 57}
+
+    slices = [bayer.get_stamp_slice(x, y, stamp_size=(6, 6)) for x, y in positions]
+    # They should all be the same
+    for s0 in slices:
+        assert s0 == (slice(2, 8, None), slice(4, 10, None))
+
+
+def test_get_stamp_slice_fail():
+    # Nothing small
+    with pytest.raises(RuntimeError):
+        bayer.get_stamp_slice(4, 4, stamp_size=(4, 4))
+
+    # Nothing odd
+    with pytest.raises(RuntimeError):
+        bayer.get_stamp_slice(512, 514, stamp_size=(15, 15))
+
+    # Nothing where (i-2) % 4 != 0
+    with pytest.raises(RuntimeError):
+        bayer.get_stamp_slice(512, 514, stamp_size=(12, 12))
+    with pytest.raises(RuntimeError):
+        bayer.get_stamp_slice(512, 514, stamp_size=(100, 100))

--- a/resources/sextractor/panoptes.sex
+++ b/resources/sextractor/panoptes.sex
@@ -40,7 +40,7 @@ FLAG_TYPE        OR             # flag pixel combination: OR, AND, MIN, MAX
 
 #------------------------------ Photometry -----------------------------------
 
-PHOT_APERTURES   6              # MAG_APER aperture diameter(s) in pixels
+PHOT_APERTURES   5              # MAG_APER aperture diameter(s) in pixels
 PHOT_AUTOPARAMS  2.5, 3.5       # MAG_AUTO parameters: <Kron_fact>,<min_radius>
 PHOT_PETROPARAMS 2.0, 3.5       # MAG_PETRO parameters: <Petrosian_fact>,
                                 # <min_radius>
@@ -50,15 +50,15 @@ PHOT_AUTOAPERS   0.0,0.0        # <estimation>,<measurement> minimum apertures
 SATUR_LEVEL      13550.0        # level (in ADUs) at which arises saturation
 SATUR_KEY        SATURATE       # keyword for saturation level (in ADUs)
 
-MAG_ZEROPOINT    25.0            # magnitude zero-point
+MAG_ZEROPOINT    25.0           # magnitude zero-point
 MAG_GAMMA        4.0            # gamma of emulsion (for photographic scans)
-GAIN             1.5           # detector gain in e-/ADU
+GAIN             1.5            # detector gain in e-/ADU
 GAIN_KEY         GAIN           # keyword for detector gain in e-/ADU
-PIXEL_SCALE      10.3            # size of pixel in arcsec (0=use FITS WCS info)
+PIXEL_SCALE      10.3           # size of pixel in arcsec (0=use FITS WCS info)
 
 #------------------------- Star/Galaxy Separation ----------------------------
 
-SEEING_FWHM      15.3            # stellar FWHM in arcsec
+SEEING_FWHM      1.5            # stellar FWHM in arcsec
 STARNNW_NAME     /usr/share/sextractor/default.nnw    # Neural-Network_Weight table filename
 
 #------------------------------ Background -----------------------------------


### PR DESCRIPTION
* Add `bayer.get_stamp_slice` for getting a stamp slice while respecting the superpixel. This was removed awhile ago and has been re-added and improved.
* Only support getting stars directly from the WCS, not the footprint.
  * `get_stars_from_footprint` -> `get_stars_from_wcs`
  * Better logging
  * Consistent column names for dtypes
  * Vmag bin comes from sql.
  * Allow for different RA/Dec column names.
  * Better catalog match function.
* sextractor param changes

