### PR TITLE
Generic wait_for_events utility.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,17 +7,20 @@ All notable changes to this project will be documented in this file.
 0.2.16dev
 ---------
 
-**Added**
+Added
+^^^^^
 
 * Added CR2 file testing to GitHub Actions. (#125, #205)
 * A `wait_for_events` generic utility, mostly pulled from POCS. (#92, #206)
 
-**Changed**
+Changed
+^^^^^^^
 
 * Remove the `validate_collection` requirement from the database types, making any collection is now valid. (#204)
 * Rearrange some of the `panoptes.utils.database` modules. (#204)
 
-**Removed**
+Removed
+^^^^^^^
 
 * Remove `error.InvalidCollection`. (#204)
 * Unused items in `conftest.py`. (#204)
@@ -25,9 +28,10 @@ All notable changes to this project will be documented in this file.
 0.2.15 - 2020-05-26
 -------------------
 
-**Changed**
+Changed
+^^^^^^^
 
-* Convert to [pyscaffold](https://pyscaffold.org/en/latest/index.html). (#198)
+* Convert to `pyscaffold`_. (#198)
 
   * Proper namespace package `panoptes`.
   * Move items to `src` folder.
@@ -38,7 +42,8 @@ All notable changes to this project will be documented in this file.
   * Base Docker image is run by root only.
   * Added a `testing` Dockerfile and cleaned up `latest` and `develop`.
 
-**Removed**
+Removed
+^^^^^^^
 
 * **Breaking** Removing all zmq based messaging services. (#200)
 
@@ -46,7 +51,8 @@ All notable changes to this project will be documented in this file.
 0.2.14 - 2020-05-23
 -------------------
 
-**Added**
+Added
+^^^^^
 
 * Add snappy decompression for parquet; `pyarrow` instead of `fastparquet` (#193)
 * Password-less sudo for panoptes user on dev docker image (#193)
@@ -57,7 +63,8 @@ All notable changes to this project will be documented in this file.
     G2 B
     R  G1
 
-**Bug fixes**
+Bug fixes
+^^^^^^^^^
 
 * Fix time-based search (#193)
 * Fix the build (#197)
@@ -65,7 +72,8 @@ All notable changes to this project will be documented in this file.
   * Removed the MANIFEST.in
   * Added a simple `pyproject.toml`.
 
-**Changed**
+Changed
+^^^^^^^
 
 * **Breaking** Only support getting stars directly from the WCS, not the footprint. (#194)
   * `get_stars_from_footprint` -> `get_stars_from_wcs`
@@ -84,11 +92,13 @@ All notable changes to this project will be documented in this file.
 0.2.13 - 2020-05-14
 -------------------
 
-**Bug fixes**
+Bug fixes
+^^^^^^^^^
 
 * Fix some passing of options between `get_solve_field` and `solve_field` that was leading to double parameter issues. (#189)
 
-**Changed**
+Changed
+^^^^^^^
 
 * The `panoptes.utils.data` functions use static versions of the file rather than firestore. (#192)
 * Updated development environment (#191)
@@ -99,18 +109,21 @@ All notable changes to this project will be documented in this file.
 
 Quick release to get the `panoptes.utils.sources` into the package.
 
-**Bug fixes**
+Bug fixes
+^^^^^^^^^
 
 * `panoptes.utils.sources` not included in package. (#187, #188)
 
-**Changed**
+Changed
+^^^^^^^
 
 * Ability to pass credentials to underlying google client functions. (#187)
 
 0.2.11 - 2020-04-29
 -------------------
 
-**Added**
+Added
+^^^^^
 
 * Data
     * Added basic data access components for getting observation and image metadata. (#178, #181)
@@ -120,7 +133,8 @@ Quick release to get the `panoptes.utils.sources` into the package.
     * Adding `holoviews` and `hvplot` as required dependencies.
 
 
-**Bug fixes**
+Bug fixes
+^^^^^^^^^
 
 * FITS Utils fixes:
     * Fix docstring return types for some functions. (#173)
@@ -129,7 +143,8 @@ Quick release to get the `panoptes.utils.sources` into the package.
         the compressed version. (#175)
     * Properly pass `args` and `kwargs` to `astropy.io.fits.getdata`. (#180)
 
-**Changed**
+Changed
+^^^^^^^
 
 * Docker
     * Changed developer tag from `dev` to `develop`. (#174)
@@ -148,7 +163,8 @@ Quick release to get the `panoptes.utils.sources` into the package.
     * **BREAKING** The `panoptes.utils.data.py` has moved into the `panoptes.utils.data` namespace with the relevant existing `Downloader` class placed in the `assets.py` module. (#181)
     * Changed the `get_data` (and images and observations equivalent) to `get_metadata`. (#181)
 
-**Removed**
+Removed
+^^^^^^^
 
 FITS Utils removals (#173):
     * Removing unused and confusing `improve_wcs`.
@@ -157,7 +173,8 @@ FITS Utils removals (#173):
 0.2.10 - 2020-04-13
 -------------------
 
-**Added**
+Added
+^^^^^
 
 * `get_stars_from_footpr  int` can accept a `WCS` directly instead of just the output from `calc_footprint()`. (#164)
 * Ability to create different tags for the docker image. The `develop` directory is now used to create a `develop` image and is provided along with `latest`. (#165)
@@ -165,21 +182,23 @@ FITS Utils removals (#173):
 * Added BigQuery pandas dependencies. (#168)
 * Added a developer image at `panoptes-utils:dev`, which is also auto-built along with the `latest` in the cloudbuild. Offers a `jupyter-lab` instance along with a number of plotting modules. Can be easily started via `panoptes-dev`. (#170, #171)
 
-**Bug fixes**
+Bug fixes
+^^^^^^^^^
 
 * `image_id_from_path` and `sequence_id_from_path` can recognize a zero in the `camera_id` and `None` when no match. (#163)
 * Fixed the bigquery client param for star lookup. (#164)
 * Unquote paths before id matching. (#169)
 * Do WCS match for all unmatched sources, not just matched sources. (#172)
 
-**Changed**
+Changed
+^^^^^^^
 
 * Docker entrypoint no longer tries to activate service account if `$GOOGLE_APPLICATION_CREDENTIALS` is found. The python client libraries will recognize the env var so this means we can avoid installing `gcloud` utilities just to activate. (#165)
 * The `sources` module does not require a BigQuery client to be passed but can start it's own. A warning is given if `$GOOGLE_APPLICATION_CREDENTIALS` is not found. (#167)
 * `lookup_point_sources` updates: default vmag range expanded so less false positive matches [4,18). (#168)
 * Removed TOC from changelog. (#170)
 * Sextractor param changes: (#171)
-  * Threshold for detecton changed from 3 pixels to 10 pixels.
+  * Threshold for detection changed from 3 pixels to 10 pixels.
   * Seeing changed from 0.7 arcsec to 15.3 arcsec. (Isn't used.)
   * Removed `class_star` from sextractor results.
 
@@ -194,7 +213,8 @@ Pointless version bump because of issue with [PyPi](https://github.com/pypa/pack
 
 Thanks first-time contributer @preethi524! :tada:
 
-**Changed**
+Changed
+^^^^^^^
 
 * Ability to return separate RGB backgrounds. (#162)
 * Increase coverage. (#161)
@@ -202,28 +222,33 @@ Thanks first-time contributer @preethi524! :tada:
 0.2.7 - 2020-03-22 (hotfix)
 ---------------------------
 
-**Added**
+Added
+^^^^^
 
 * Basic serialization of `Exception`. (#160)
 
-**Bug fixes**
+Bug fixes
+^^^^^^^^^
 
 * Add `args` and `kwargs` to `get_rgb_background`. (#160)
 
 0.2.6 - 2020-03-22
 ------------------
 
-**Added**
+Added
+^^^^^
 
 * `get_rgb_background` added to the `bayer` module. (#158)
 * `getwcs` thin-wrapper added to `fits` module. (#158)
 * Added `sources` utils. (#158)
 
-**Bug fixes**
+Bug fixes
+^^^^^^^^^
 
 * Changed scope of test data files to `function`. (#158)
 
-**Changed**
+Changed
+^^^^^^^
 
 * Docker
   * Change to `python:3.8-slim-buster` for base image. Only `amd64` support for now. (#155)
@@ -239,7 +264,8 @@ Thanks first-time contributer @preethi524! :tada:
   * Added `pandas`. (#158)
   * Default `panoptes` user has password `panoptes`. (#158)
 
-**Removed**
+Removed
+^^^^^^^
 
 * Docker (#155)
   * Remove anaconda
@@ -249,50 +275,59 @@ Thanks first-time contributer @preethi524! :tada:
 0.2.5 - 2020-03-18
 ------------------
 
-**Added**
+Added
+^^^^^
 
 * Github Actions testing and coverage upload. (#145)
   * Log files for testing are created as an artifact.
 * `PanLogger` helper class added. Mostly handles formatting but can also track handlers. (#145)
 
-**Bug fixes**
+Bug fixes
+^^^^^^^^^
 
 * Fixed top-level namespace so we can have other `panoptes` repos. (#150, fixes #137)
 
-**Changed**
+Changed
+^^^^^^^
 
 * Data files for testing are copied before tests. Allows for reuse of unsolved fits file. (#144)
 * Fix astrometry data file directories in Docker images. (#144)
 
-**Removed**
+Removed
+^^^^^^^
 
 * The docker image no longer updates `panoptes-utils` when using `run-tests.sh`. (#145)
 
 0.2.4 - 2020-03-11
 ------------------
 
-**Changed**
+Changed
+^^^^^^^
 
 * Disallow zipped packages, which also interfere with namespace (#142)
 
-**Removed**
+Removed
+^^^^^^^
 
-* `photutils` dependency for recangular apertures in the `show_stamps` method.
+* `photutils` dependency for rectangular apertures in the `show_stamps` method.
 
 0.2.3 - 2020-03-08
 ------------------
 
 Small point release to correct namespace and remove some bloat.
 
-**Changed**
+Changed
+^^^^^^^
 
 * Fixed top-level namespace so we can have other `panoptes` repos. (#137)
 
-**Removed**
+Removed
+^^^^^^^
 
 * Dependencies that will be deprecated soon and are causing bloat: `photutils`, `scikit-image`. (#138)
 
-**Changed**
+Changed
+^^^^^^^
 
 * Fixed top-level namespace so we can have other `panoptes` repos (#137, #150).
 
@@ -301,17 +336,20 @@ Small point release to correct namespace and remove some bloat.
 
 Mostly some cleanup from the `v0.2.0` release based on integrating all the changes into POCS.
 
-**Bug fixes**
+Bug fixes
+^^^^^^^^^
 
 * Misc bugs introduced as part of last release, including to `download-data.py` script.
 * Custom exceptions now properly pass `kwargs` through to parent (#135).
 
-**Changed**
+Changed
+^^^^^^^
 
 * New script for downloading data, `scripts/download-data.py`. This helped resolve some issues with the relative imports introduced in `v0.2.0` and is cleaner. (#129)
 * All dependencies are smashed into one "feature" in `setup.py` to make `pip-tools` work well. This will fix the docker image problems introduced in `v0.2.1`. (#136)
 
-**Removed**
+Removed
+^^^^^^^
 
 * The `get_root_logger` and associated tests (#134).
 
@@ -320,16 +358,19 @@ Mostly some cleanup from the `v0.2.0` release based on integrating all the chang
 
 First big overhaul of the repository. Pulls in features that were duplicated or scattered across [POCS](https://github.com/panoptes/POCS.git) and [PIAA](https://github.com/panoptes/PIAA.git). Removes a lot of code that wasn't being used or was otherwise clutter. Overhauls the logging system to use [`loguru`](https://github.com/Delgan/loguru) so things are simplified. Updates to documentation.
 
-**Added**
+Added
+^^^^^
 * Config Server
 * See the description in the [README](README.md)
 * [Versioneer](https://github.com/warner/python-versioneer) for version strings (#123).
 * Read the docs config (#123).
 
-**Bug fixes**
+Bug fixes
+^^^^^^^^^
 * IERS Mirror (#65, #67)
 
-**Changed**
+Changed
+^^^^^^^
 * Docker updates
 * See #68 and #75 for list.
 * Logging:
@@ -350,21 +391,24 @@ Changes and cleanup on the way to a (more) stable release. See `0.2.0` for list 
 
 Bringing things in line with updates to `POCS` for docker and `panoptes-utils` use.
 
-**Added**
+Added
+^^^^^
 
 * Serial handlers move to panoptes-utils from POCS.
 * Tests and coverage.
 * `improve_wcs` (moved from PIAA).
 * `~utils.fits.getdata` to match other fits convenience functions, allowing for fpack files.
 
-**Bug fixes**
+Bug fixes
+^^^^^^^^^
 
 * Serialization fixes.
   * Use our serialization everywhere (e.g. messaging)
   * Closes #panoptes/POCS/issues/818
   * Closes #panoptes/POCS/issues/103
 
-**Changed**
+Changed
+^^^^^^^
 
 * Setup/Install:
   * Scripts are renamed to have `panoptes` prefix.
@@ -382,12 +426,14 @@ Bringing things in line with updates to `POCS` for docker and `panoptes-utils` u
 0.0.7 - 2019-05-26
 -------------------
 
-**Added**
+Added
+^^^^^
 
 * Added bayer utilities. :camera:
 * Added Cloud SQL utilities. :cloud:
 
-**Changed**
+Changed
+^^^^^^^
 
 * **Breaking** Changed namespace so no underscores, i.e. `from panoptes.utils import time`.
 * Docker updates:
@@ -399,7 +445,8 @@ Bringing things in line with updates to `POCS` for docker and `panoptes-utils` u
 0.0.6 - 2019-04-29
 -------------------
 
-**Added**
+Added
+^^^^^
 
 * Docker containers created:
   * `panoptes-base` for base OS and system packages, including astrometry.net and friends.
@@ -408,7 +455,8 @@ Bringing things in line with updates to `POCS` for docker and `panoptes-utils` u
 * Consistent JSON and YAML serializers.
 * Configuration Server (Flask/JSON microservice).
 
-**Changed**
+Changed
+^^^^^^^
 
 * **Minimum Python version is 3.6**
 * Default PanDB type is changed to `memory`.
@@ -418,14 +466,18 @@ Bringing things in line with updates to `POCS` for docker and `panoptes-utils` u
 0.0.5 - 2019-04-09
 -------------------
 
-**Added**
+Added
+^^^^^
 
-* Added a change log :tada:
+* Added a change log. Yay.
 
-**Changed**
+Changed
+^^^^^^^
 
 * Drop `orjson` and revert to `json` for the JSON serializers.
 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+.. _pyscaffold: https://pyscaffold.org/en/latest/index.html

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 **Added**
 
 * Added CR2 file testing to GitHub Actions. (#125, #205)
+* A `wait_for_events` generic utility, mostly pulled from POCS. (#206)
 
 **Changed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 **Added**
 
 * Added CR2 file testing to GitHub Actions. (#125, #205)
-* A `wait_for_events` generic utility, mostly pulled from POCS. (#206)
+* A `wait_for_events` generic utility, mostly pulled from POCS. (#92, #206)
 
 **Changed**
 

--- a/src/panoptes/utils/time.py
+++ b/src/panoptes/utils/time.py
@@ -267,14 +267,14 @@ def wait_for_events(events,
 
     start_time = current_time()
     while not all([event.is_set() for event in events]):
-        elapsed_secs = (current_time() - start_time).to_value('second')
+        elapsed_secs = round((current_time() - start_time).to_value('second'), 2)
 
         if callable(interrupt_cb) and interrupt_cb():
             logger.info(f"Waiting for events has been interrupted after {elapsed_secs} seconds")
             break
 
         if msg_timer.expired():
-            logger.debug(f'Waiting for {event_type} events: {round(elapsed_secs)} seconds elapsed')
+            logger.debug(f'Waiting for {event_type} events: {elapsed_secs} seconds elapsed')
             msg_timer.restart()
 
         if event_timer.expired():

--- a/src/panoptes/utils/time.py
+++ b/src/panoptes/utils/time.py
@@ -213,20 +213,28 @@ def wait_for_events(events,
         >>> import time
         >>> import threading
         >>> from panoptes.utils.time import wait_for_events
-        >>> from panoptes.utils.time import current_time
         >>> # Create some events, normally something like taking an image.
         >>> event0 = threading.Event()
         >>> event1 = threading.Event()
 
-        >>> # Wait for 30 seconds but interrupt after 1 second by returning True.
+        >>> # Wait for 30 seconds but interrupt after 1 second by returning True from interrupt.
         >>> def interrupt(): time.sleep(1); return True
-        >>> start_time = current_time()
+        >>> # The function will return False if events are not set.
         >>> wait_for_events([event0, event1], timeout=30, interrupt_cb=interrupt)
+        False
+
+        >>> # Timeout will raise an exception.
+        >>> wait_for_events([event0, event1], timeout=1)
+        Traceback (most recent call last):
+          File "<input>", line 1, in <module>
+          File ".../panoptes-utils/src/panoptes/utils/time.py", line 254, in wait_for_events
+        panoptes.utils.error.Timeout: Timeout: Timeout waiting for generic event
 
         >>> # Set the events in another thread for normal usage.
         >>> def set_events(): time.sleep(1); event0.set(); event1.set()
         >>> threading.Thread(target=set_events).start()
         >>> wait_for_events([event0, event1], timeout=30)
+        True
 
     Args:
         events (list(`threading.Event`)): An Event or list of Events to wait on.
@@ -238,6 +246,9 @@ def wait_for_events(events,
             default 'generic'.
         interrupt_cb (callable): A callback for interrupting that can stop the wait if it
             returns True, default None (no callback).
+
+    Returns:
+        bool: True if events were set, False otherwise.
 
     Raises:
         error.Timeout: Raised if events have not all been set before `timeout` seconds.
@@ -268,3 +279,5 @@ def wait_for_events(events,
 
         # Sleep for a little bit.
         event_timer.sleep(max_sleep=sleep_delay)
+
+    return all([event.is_set() for event in events])

--- a/src/panoptes/utils/time.py
+++ b/src/panoptes/utils/time.py
@@ -213,13 +213,18 @@ def wait_for_events(events,
         >>> # Create some events, normally something like taking an image.
         >>> event0 = threading.Event()
         >>> event1 = threading.Event()
-        >>> # Wait for 30 seconds but interrupt after 1.
+        >>> # Wait for 30 seconds but interrupt after 1 second by returning True.
         >>> def interrupt(): time.sleep(1); return True
         >>> start_time = current_time()
         >>> wait_for_events([event0, event1], timeout=30, interrupt_cb=interrupt)
         >>> assert (current_time() - start_time).sec < 2
 
-        >>> # If the events are
+        >>> # If the events are set then the function will return immediately
+        >>> event0.set()
+        >>> event1.set()
+        >>> start_time = current_time()
+        >>> wait_for_events([event0, event1], timeout=30, interrupt_cb=interrupt)
+        >>> assert (current_time() - start_time).sec < 1
 
     Args:
         events (list(`threading.Event`)): An Event or list of Events to wait on.

--- a/src/panoptes/utils/time.py
+++ b/src/panoptes/utils/time.py
@@ -1,5 +1,6 @@
 import os
 import time
+from contextlib import suppress
 from datetime import timezone as tz
 
 from astropy import units as u
@@ -189,7 +190,7 @@ class CountdownTimer(object):
 
 
 def wait_for_events(events,
-                    timeout,
+                    timeout=600,
                     sleep_delay=1 * u.second,
                     msg_interval=30 * u.second,
                     event_type='generic',
@@ -213,22 +214,21 @@ def wait_for_events(events,
         >>> # Create some events, normally something like taking an image.
         >>> event0 = threading.Event()
         >>> event1 = threading.Event()
+
         >>> # Wait for 30 seconds but interrupt after 1 second by returning True.
         >>> def interrupt(): time.sleep(1); return True
         >>> start_time = current_time()
         >>> wait_for_events([event0, event1], timeout=30, interrupt_cb=interrupt)
-        >>> assert (current_time() - start_time).sec < 2
 
-        >>> # If the events are set then the function will return immediately
-        >>> event0.set()
-        >>> event1.set()
-        >>> start_time = current_time()
-        >>> wait_for_events([event0, event1], timeout=30, interrupt_cb=interrupt)
-        >>> assert (current_time() - start_time).sec < 1
+        >>> # Set the events in another thread for normal usage.
+        >>> def set_events(): time.sleep(1); event0.set(); event1.set()
+        >>> threading.Thread(target=set_events).start()
+        >>> wait_for_events([event0, event1], timeout=30)
 
     Args:
         events (list(`threading.Event`)): An Event or list of Events to wait on.
-        timeout (float|`astropy.units.Quantity`): Timeout in seconds to wait for events.
+        timeout (float|`astropy.units.Quantity`): Timeout in seconds to wait for events,
+            default 600 seconds.
         sleep_delay (float, optional): Time in seconds between event checks.
         msg_interval (float, optional): Time in seconds between sending of log messages.
         event_type (str, optional): The type of event, used for outputting in log messages,
@@ -239,10 +239,10 @@ def wait_for_events(events,
     Raises:
         error.Timeout: Raised if events have not all been set before `timeout` seconds.
     """
-    if isinstance(sleep_delay, u.Quantity):
-        sleep_delay = sleep_delay.to(u.second).value
+    with suppress(AttributeError):
+        sleep_delay = sleep_delay.to_value('second')
 
-    timer = CountdownTimer(timeout)
+    event_timer = CountdownTimer(timeout)
     msg_timer = CountdownTimer(msg_interval)
 
     if not isinstance(events, list):
@@ -259,8 +259,8 @@ def wait_for_events(events,
             logger.debug(f'Waiting for {event_type} events: {round(elapsed_secs)} seconds elapsed')
             msg_timer.restart()
 
-        if timer.expired():
+        if event_timer.expired():
             raise error.Timeout(f"Timeout waiting for {event_type} event")
 
         # Sleep for a little bit.
-        timer.sleep(max_sleep=sleep_delay)
+        event_timer.sleep(max_sleep=sleep_delay)

--- a/src/panoptes/utils/time.py
+++ b/src/panoptes/utils/time.py
@@ -260,7 +260,7 @@ def wait_for_events(events,
     msg_timer = CountdownTimer(msg_interval)
 
     if not isinstance(events, list):
-        events = list(events)
+        events = [events]
 
     start_time = current_time()
     while not all([event.is_set() for event in events]):

--- a/src/panoptes/utils/time.py
+++ b/src/panoptes/utils/time.py
@@ -193,20 +193,23 @@ def wait_for_events(events,
                     timeout=600,
                     sleep_delay=1 * u.second,
                     msg_interval=30 * u.second,
+                    interrupt_cb=None,
                     event_type='generic',
-                    interrupt_cb=None
                     ):
     """Wait for event(s) to be set.
 
-    This method will wait for a maximum of `timeout` seconds for all of the
-    `events` to complete.
+    This method will wait for a maximum of `timeout` seconds for all of the `events`
+    to complete.
 
-    Will check at least every `sleep_delay` seconds for the events to be done,
-    and also for interrupts and bad weather. Will log debug messages approximately
-    every `msg_interval` seconds.
+    Checks every `sleep_delay` seconds for the events to be set.
 
-    The interrupt is provided via the `interrupt_cb`, which must be a `callable` that
-    returns `True` to interrupt the wait loop, `False` otherwise.
+    Will log debug messages approximately every `msg_interval` seconds.
+
+    The wait loop can be interrupted via `interrupt_cb`, which must be a `callable`
+    that returns `True` to interrupt the wait loop, `False` otherwise. The call will
+    happen approximately every `sleep_delay` seconds.
+
+    The `event_type` parameter is merely for logging purposes.
 
     .. doctest::
 
@@ -242,10 +245,10 @@ def wait_for_events(events,
             default 600 seconds.
         sleep_delay (float, optional): Time in seconds between event checks.
         msg_interval (float, optional): Time in seconds between sending of log messages.
-        event_type (str, optional): The type of event, used for outputting in log messages,
-            default 'generic'.
         interrupt_cb (callable): A callback for interrupting that can stop the wait if it
             returns True, default None (no callback).
+        event_type (str, optional): The type of event, used for outputting in log messages,
+            default 'generic'.
 
     Returns:
         bool: True if events were set, False otherwise.

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -101,7 +101,7 @@ def test_wait_for_events():
 
     start_time = current_time()
     wait_for_events([event0, event1], timeout=30, interrupt_cb=interrupt)
-    assert (current_time() - start_time).sec - 2 == pytest.approx(0, rel=1e-2)
+    assert (current_time() - start_time).sec - 2 < 1
 
     # Timeout if event is never set.
     with pytest.raises(error.Timeout):
@@ -121,4 +121,4 @@ def test_wait_for_events():
     # If the events are set then the function will return immediately
     start_time = current_time()
     wait_for_events([event0, event1], timeout=30)
-    assert (current_time() - start_time).sec - 1 == pytest.approx(0, rel=1e-2)
+    assert (current_time() - start_time).sec - 1 < 1

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -101,7 +101,7 @@ def test_wait_for_events():
 
     start_time = current_time()
     wait_for_events([event0, event1], timeout=30, interrupt_cb=interrupt)
-    assert (current_time() - start_time).sec - 2 == pytest.approx(0)
+    assert (current_time() - start_time).sec - 2 == pytest.approx(0, rel=1e-2)
 
     # Timeout if event is never set.
     with pytest.raises(error.Timeout):
@@ -121,4 +121,4 @@ def test_wait_for_events():
     # If the events are set then the function will return immediately
     start_time = current_time()
     wait_for_events([event0, event1], timeout=30)
-    assert (current_time() - start_time).sec - 1 == pytest.approx(0)
+    assert (current_time() - start_time).sec - 1 == pytest.approx(0, rel=1e-2)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -115,6 +115,4 @@ def test_wait_for_events():
     assert wait_for_events([event0, event1], msg_interval=1, timeout=30)
 
     # If the events are set then the function will return immediately
-    start_time = current_time()
-    wait_for_events([event0, event1], timeout=30)
-    assert (current_time() - start_time).sec < 1
+    assert wait_for_events([event0, event1], timeout=30)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -101,7 +101,7 @@ def test_wait_for_events():
 
     start_time = current_time()
     wait_for_events([event0, event1], timeout=30, interrupt_cb=interrupt)
-    assert (current_time() - start_time).sec - 2 < 1
+    assert (current_time() - start_time).sec == pytest.approx(3, rel=1e-2)
 
     # Timeout if event is never set.
     with pytest.raises(error.Timeout):
@@ -121,4 +121,4 @@ def test_wait_for_events():
     # If the events are set then the function will return immediately
     start_time = current_time()
     wait_for_events([event0, event1], timeout=30)
-    assert (current_time() - start_time).sec - 1 < 1
+    assert (current_time() - start_time).sec < 1

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -101,7 +101,7 @@ def test_wait_for_events():
 
     start_time = current_time()
     wait_for_events([event0, event1], timeout=30, interrupt_cb=interrupt)
-    assert (current_time() - start_time).sec < 2
+    assert (current_time() - start_time).sec - 2 == pytest.approx(0)
 
     # Timeout if event is never set.
     with pytest.raises(error.Timeout):
@@ -121,4 +121,4 @@ def test_wait_for_events():
     # If the events are set then the function will return immediately
     start_time = current_time()
     wait_for_events([event0, event1], timeout=30)
-    assert (current_time() - start_time).sec < 1
+    assert (current_time() - start_time).sec - 1 == pytest.approx(0)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -2,12 +2,15 @@ import os
 import pytest
 
 import time
+import threading
 from datetime import timezone as tz
 from datetime import datetime as dt
 from astropy import units as u
 
+from panoptes.utils import error
 from panoptes.utils import current_time
 from panoptes.utils import CountdownTimer
+from panoptes.utils.time import wait_for_events
 
 
 def test_pretty_time():
@@ -84,3 +87,38 @@ def test_countdown_timer_sleep():
     assert timer.time_left() == 0
     assert timer.expired() is True
     assert timer.sleep() is False
+
+
+def test_wait_for_events():
+    # Create some events, normally something like taking an image.
+    event0 = threading.Event()
+    event1 = threading.Event()
+
+    # Wait for 30 seconds but interrupt after 1 second by returning True.
+    def interrupt():
+        time.sleep(1)
+        return True
+
+    start_time = current_time()
+    wait_for_events([event0, event1], timeout=30, interrupt_cb=interrupt)
+    assert (current_time() - start_time).sec < 2
+
+    # Timeout if event is never set.
+    with pytest.raises(error.Timeout):
+        wait_for_events(event0, timeout=1)
+
+    # Setting events causes timer to exit.
+    def set_events():
+        time.sleep(3)
+        event0.set()
+        event1.set()
+
+    start_time = current_time()
+    threading.Thread(target=set_events).start()
+    wait_for_events([event0, event1], msg_interval=1, timeout=30)
+    assert (current_time() - start_time).sec > 3
+
+    # If the events are set then the function will return immediately
+    start_time = current_time()
+    wait_for_events([event0, event1], timeout=30)
+    assert (current_time() - start_time).sec < 1

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -99,9 +99,7 @@ def test_wait_for_events():
         time.sleep(1)
         return True
 
-    start_time = current_time()
-    wait_for_events([event0, event1], timeout=30, interrupt_cb=interrupt)
-    assert (current_time() - start_time).sec == pytest.approx(3, rel=1e-2)
+    assert wait_for_events([event0, event1], timeout=30, interrupt_cb=interrupt) is False
 
     # Timeout if event is never set.
     with pytest.raises(error.Timeout):
@@ -113,10 +111,8 @@ def test_wait_for_events():
         event0.set()
         event1.set()
 
-    start_time = current_time()
     threading.Thread(target=set_events).start()
-    wait_for_events([event0, event1], msg_interval=1, timeout=30)
-    assert (current_time() - start_time).sec > 3
+    assert wait_for_events([event0, event1], msg_interval=1, timeout=30)
 
     # If the events are set then the function will return immediately
     start_time = current_time()


### PR DESCRIPTION
Adding the `wait_for_events` and making more generic. Example usage in the docstring.

Replaces the `pocs.wait_for_events` that is used to control some of the state logic.

Slipping in some changelog reformatting. Just changing headings.

Closes #92 (sure, why not?)