### PR TITLE
Config server tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Changelog
 Changed
 ^^^^^^^
 
+* Python minimum version changed to ``3.8``. (#217)
 * Cleaning up the config_server. (#217)
     * Better logging.
     * Cleaning up doctests.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,23 @@
 Changelog
 =========
 
-All notable changes to this project will be documented in this file.
+0.2.20dev
+---------
+
+Changed
+^^^^^^^
+
+* Cleaning up the config_server. (#217)
+    * Better logging.
+    * Cleaning up doctests.
+    * Removing all dynamic server items from this repo as they are not needed.
+    * Wait for config_server to start.
+    * Fixing starting within fixture.
+
+* Serializers update. (#217)
+    * Make the parsing and serializing functions public.
+    * Use pendulum for parsing times instead of astropy Time.
+
 
 0.2.19 - 2020-06-04
 -------------------

--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,3 @@
-# This is in the root PANDIR directory so that pytest will recognize the
-# options added below without having to also specify pocs/test, or a
-# one of the tests in that directory, on the command line; i.e. pytest
-# doesn't load pocs/tests/conftest.py until after it has searched for
-# tests.
-# In addition, there are fixtures defined here that are available to
-# all tests, not just those in pocs/tests.
-
 import os
 import copy
 import pytest

--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,6 @@
 
 import os
 import copy
-import subprocess
 import pytest
 import time
 import shutil
@@ -20,6 +19,7 @@ from contextlib import suppress
 
 from panoptes.utils.logging import logger
 from panoptes.utils.database import PanDB
+from panoptes.utils.config.client import get_config
 from panoptes.utils.config.client import set_config
 from panoptes.utils.config.server import config_server
 
@@ -47,6 +47,7 @@ logger.add(log_file_path,
            backtrace=True,
            diagnose=True,
            level='TRACE')
+logger.log('testing', '*' * 25 + ' STARTING NEW PYTEST RUN ' + '*' * 25)
 
 
 def pytest_addoption(parser):
@@ -83,27 +84,6 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope='session')
-def config_host():
-    return 'localhost'
-
-
-@pytest.fixture(scope='session')
-def static_config_port():
-    """Used for the session-scoped config_server where no config values
-    are expected to change during testing.
-    """
-    return '6563'
-
-
-@pytest.fixture(scope='module')
-def config_port():
-    """Used for the function-scoped config_server when it is required to change
-    config values during testing. See `dynamic_config_server` docs below.
-    """
-    return '4861'
-
-
-@pytest.fixture(scope='session')
 def db_name():
     return 'panoptes_testing'
 
@@ -116,95 +96,46 @@ def images_dir(tmpdir_factory):
 
 @pytest.fixture(scope='session')
 def config_path():
-    return os.path.join(os.getenv('PANDIR'),
-                        'panoptes-utils',
-                        'tests',
-                        'panoptes_utils_testing.yaml'
-                        )
+    return os.path.expandvars('${PANDIR}/panoptes-utils/tests/panoptes_utils_testing.yaml')
 
 
 @pytest.fixture(scope='session', autouse=True)
-def static_config_server(config_host, static_config_port, config_path, images_dir, db_name):
-    print(f'Starting config_server for testing session')
+def static_config_server(config_path, images_dir, db_name):
+    logger.log('testing', f'Starting static_config_server for testing session')
 
     proc = config_server(
-        host=config_host,
-        port=static_config_port,
         config_file=config_path,
         ignore_local=True,
+        auto_save=False
     )
 
-    print(f'config_server started with PID={proc.pid}')
+    logger.log('testing', f'static_config_server started with {proc.pid=}')
 
     # Give server time to start
-    time.sleep(1)
+    while get_config('name') is None:
+        logger.log('testing', f'Waiting for static_config_server {proc.pid=}, sleeping 1 second.')
+        time.sleep(1)
+
+    logger.log('testing', f'Startup config_server name=[{get_config("name")}]')
 
     # Adjust various config items for testing
-    unit_name = 'Generic PANOPTES Unit'
     unit_id = 'PAN000'
-    print(f'Setting testing name and unit_id to {unit_id}')
-    set_config('name', unit_name, port=static_config_port)
-    set_config('pan_id', unit_id, port=static_config_port)
+    logger.log('testing', f'Setting testing name and unit_id to {unit_id}')
+    set_config('pan_id', unit_id)
 
-    print(f'Setting testing database to {db_name}')
-    set_config('db.name', db_name, port=static_config_port)
+    logger.log('testing', f'Setting testing database to {db_name}')
+    set_config('db.name', db_name)
 
     fields_file = 'simulator.yaml'
-    print(f'Setting testing scheduler fields_file to {fields_file}')
-    set_config('scheduler.fields_file', fields_file, port=static_config_port)
+    logger.log('testing', f'Setting testing scheduler fields_file to {fields_file}')
+    set_config('scheduler.fields_file', fields_file)
 
     # TODO(wtgee): determine if we need separate directories for each module.
-    print(f'Setting temporary image directory for testing')
-    set_config('directories.images', images_dir, port=static_config_port)
+    logger.log('testing', f'Setting temporary image directory for testing')
+    set_config('directories.images', images_dir)
 
     yield
-    print(f'Killing config_server started with PID={proc.pid}')
-    proc.terminate()
-
-
-@pytest.fixture(scope='function')
-def dynamic_config_server(config_host, config_port, config_path, images_dir, db_name):
-    """If a test requires changing the configuration we use a function-scoped testing
-    server. We only do this on tests that require it so we are not constantly starting and stopping
-    the config server unless necessary.  To use this, each test that requires it must use the
-    `dynamic_config_server` and `config_port` fixtures and must pass the `config_port` to all
-    instances that are created (propogated through PanBase).
-    """
-
-    print(f'Starting config_server for testing function')
-
-    proc = config_server(
-        host=config_host,
-        port=config_port,
-        config_file=config_path,
-        ignore_local=True,
-    )
-
-    print(f'config_server started with PID={proc.pid}')
-
-    # Give server time to start
-    time.sleep(1)
-
-    # Adjust various config items for testing
-    unit_name = 'Generic PANOPTES Unit'
-    unit_id = 'PAN000'
-    print(f'Setting testing name and unit_id to {unit_id}')
-    set_config('name', unit_name, port=config_port)
-    set_config('pan_id', unit_id, port=config_port)
-
-    print(f'Setting testing database to {db_name}')
-    set_config('db.name', db_name, port=config_port)
-
-    fields_file = 'simulator.yaml'
-    print(f'Setting testing scheduler fields_file to {fields_file}')
-    set_config('scheduler.fields_file', fields_file, port=config_port)
-
-    # TODO(wtgee): determine if we need separate directories for each module.
-    print(f'Setting temporary image directory for testing')
-    set_config('directories.images', images_dir, port=config_port)
-
-    yield
-    print(f'Killing config_server started with PID={proc.pid}')
+    logger.log('testing', f'Killing static_config_server started with PID={proc.pid}')
     proc.terminate()
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -49,12 +49,12 @@ def pytest_addoption(parser):
         "--with-hardware",
         nargs='+',
         default=[],
-        help=("A comma separated list of hardware to test."))
+        help="A comma separated list of hardware to test.")
     group.addoption(
         "--without-hardware",
         nargs='+',
         default=[],
-        help=("A comma separated list of hardware to NOT test. "))
+        help="A comma separated list of hardware to NOT test. ")
     group.addoption(
         "--solve",
         action="store_true",
@@ -122,7 +122,6 @@ def static_config_server(config_path, images_dir, db_name):
     logger.log('testing', f'Setting testing scheduler fields_file to {fields_file}')
     set_config('scheduler.fields_file', fields_file)
 
-    # TODO(wtgee): determine if we need separate directories for each module.
     logger.log('testing', f'Setting temporary image directory for testing')
     set_config('directories.images', images_dir)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,7 @@ classifiers =
     Operating System :: POSIX
     Programming Language :: C
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3 :: Only
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Scientific/Engineering :: Physics

--- a/src/panoptes/utils/config/__init__.py
+++ b/src/panoptes/utils/config/__init__.py
@@ -1,6 +1,5 @@
 import os
 from contextlib import suppress
-from warnings import warn
 
 from ..logging import logger
 from ..utils import listify
@@ -8,38 +7,25 @@ from ..serializers import from_yaml
 from ..serializers import to_yaml
 
 
-def load_config(config_files=None, simulator=None, parse=True, ignore_local=False):
-    """Load configuation information
+def load_config(config_files=None, parse=True, ignore_local=False):
+    """Load configuration information
 
     This function supports loading of a number of different files. If no options
-    are passed to `config_files` then the default `$PANDIR/conf_files/pocs.yaml`
+    are passed to ``config_files`` then the default ``$PANDIR/conf_files/pocs.yaml``
     will be loaded. See Notes for additional information.
 
-    .. note::
+    The ``config_files`` parameter supports a number of options:
 
-        The `config_files` parameter supports a number of options:
-        * `config_files` is a list and loaded in order, so the first entry
-        will have any values overwritten by similarly named keys in the second entry.
-        * Entries can be placed in the `$PANDIR/conf_files` folder and
-        should be passed as just the file name, e.g. [`weather.yaml`, `email.yaml`]
-        for loading `$PANDIR/conf_files/weather.yaml` and `$PANDIR/conf_files/email.yaml`
-        * The `.yaml` extension will be added if not present, so list can be
-        written as just ['weather', 'email'].
-        * `config_files` can also be specified by an absolute path, which can
-        exist anywhere on the filesystem.
-        * Local versions of files can override built-in versions and are automatically
-        loaded if placed in the `$PANDIR/conf_files` folder. The files have a
-        `<>_local.yaml` name, where `<>` is the built-in file. So a
-        `$PANDIR/conf_files/pocs_local.yaml` will override any setting in the
-        default `pocs.yaml` file.
-        * Local files can be ignored (mostly for testing purposes) with the
-        `ignore_local` parameter.
+        * ``config_files`` is a list and loaded in order, so the second entry will overwrite any values specified by similarly named keys in the first entry.
+        * Entries can be placed in the ``$PANDIR/conf_files`` folder and should be passed as just the file name, e.g. ``['weather.yaml', 'email']`` for loading ``$PANDIR/conf_files/weather.yaml`` and ``$PANDIR/conf_files/email.yaml``.
+        * The ``.yaml`` extension will be added if not present, so list can be written as just ``['weather', 'email']``.
+        * ``config_files`` can also be specified by an absolute path, which can exist anywhere on the filesystem.
+        * Local versions of files can override built-in versions and are automatically loaded if placed in the ``$PANDIR/conf_files`` folder. The files have a ``<>_local.yaml`` name, where ``<>`` is the built-in file. So a ``$PANDIR/conf_files/pocs_local.yaml`` will override any setting in the default ``pocs.yaml`` file.
+        * Local files can be ignored (mostly for testing purposes) with the ``ignore_local`` parameter.
 
     Args:
         config_files (list, optional): A list of files to load as config,
             see Notes for details of how to specify files.
-        simulator (list, optional): A list of hardware items that should be
-            used as a simulator.
         parse (bool, optional): If the config file should attempt to create
             objects such as dates, astropy units, etc.
         ignore_local (bool, optional): If local files should be ignored, see
@@ -56,30 +42,30 @@ def load_config(config_files=None, simulator=None, parse=True, ignore_local=Fals
 
     config = dict()
 
-    config_dir = '{}/conf_files'.format(os.getenv('PANDIR'))
+    config_dir = os.path.expandvars('{$PANDIR}/conf_files')
 
-    for f in config_files:
-        if not f.endswith('.yaml'):
-            f = '{}.yaml'.format(f)
+    for config_file in config_files:
+        if not config_file.endswith('.yaml'):
+            config_file = f'{config_file}.yaml'
 
-        if not f.startswith('/'):
-            path = os.path.join(config_dir, f)
+        if not config_file.startswith('/'):
+            path = os.path.join(config_dir, config_file)
         else:
-            path = f
+            path = config_file
 
         try:
             _add_to_conf(config, path, parse=parse)
-        except Exception as e:
-            warn(f"Problem with config file {path}, skipping. {e}")
+        except Exception as e:  # pragma: no cover
+            logger.warning(f"Problem with config file {path}, skipping. {e!r}")
 
         # Load local version of config
         if ignore_local is False:
-            local_version = os.path.join(config_dir, f.replace('.', '_local.'))
+            local_version = os.path.join(config_dir, config_file.replace('.', '_local.'))
             if os.path.exists(local_version):
                 try:
                     _add_to_conf(config, local_version, parse=parse)
-                except Exception:
-                    warn(f"Problem with local config file {local_version}, skipping")
+                except Exception as e:  # pragma: no cover
+                    logger.warning(f"Problem with local config file {local_version}, skipping: {e!r}")
 
     # parse_config currently only corrects directory names.
     if parse:
@@ -91,12 +77,11 @@ def load_config(config_files=None, simulator=None, parse=True, ignore_local=Fals
 def save_config(path, config, overwrite=True):
     """Save config to local yaml file.
 
-    This will save any entries into the `$PANDIR/conf_files/<path>_local.yaml` file to avoid
+    This will save any entries into the ``$PANDIR/conf_files/<path>_local.yaml`` file to avoid
     clobbering what comes from the version control.
 
     Args:
-        path (str): Path to save, can be relative or absolute. See Notes
-            in `load_config`.
+        path (str): Path to save, can be relative or absolute. See Notes in ``load_config``.
         config (dict): Config to save.
         overwrite (bool, optional): True if file should be updated, False
             to generate a warning for existing config. Defaults to True
@@ -114,8 +99,7 @@ def save_config(path, config, overwrite=True):
 
     # Check full path location
     if not base.startswith('/'):
-        config_dir = os.path.join(os.environ['PANDIR'], 'conf_files')
-        base = os.path.join(config_dir, base)
+        base = os.path.join(os.environ['PANDIR'], 'conf_files', base)
 
     full_path = f'{base}{ext}'
 
@@ -124,9 +108,11 @@ def save_config(path, config, overwrite=True):
     else:
         # Create directory if does not exist
         os.makedirs(os.path.dirname(full_path), exist_ok=True)
+        logger.info(f'Saving config to {full_path}')
         with open(full_path, 'w') as f:
-            print(config)
             to_yaml(config, stream=f)
+
+    logger.info(f'Config saved.')
 
 
 def parse_config(config):
@@ -141,9 +127,8 @@ def parse_config(config):
     Returns:
         dict: Config items but with objects.
     """
-    # Prepend the base directory to relative dirs
-    if 'directories' in config:
-        base_dir = os.getenv('PANDIR')
+    base_dir = os.getenv('PANDIR')
+    with suppress(KeyError):
         for dir_name, rel_dir in config['directories'].items():
             abs_dir = os.path.normpath(os.path.join(base_dir, rel_dir))
             if abs_dir != rel_dir:
@@ -152,9 +137,7 @@ def parse_config(config):
     return config
 
 
-def _add_to_conf(config, fn, parse=False):
-    with suppress(IOError):
-        with open(fn, 'r') as f:
-            c = from_yaml(f, parse=parse)
-            if c is not None and isinstance(c, dict):
-                config.update(c)
+def _add_to_conf(config, conf_fn, parse=False):
+    with suppress(IOError, TypeError):
+        with open(conf_fn, 'r') as fn:
+            config.update(from_yaml(fn, parse=parse))

--- a/src/panoptes/utils/config/client.py
+++ b/src/panoptes/utils/config/client.py
@@ -14,21 +14,29 @@ def get_config(key=None, host='localhost', port='6563', parse=True, default=None
     Nested keys can be specified as a string, as per [scalpl](https://pypi.org/project/scalpl/).
 
     Examples:
+
+    .. doctest::
+
         >>> get_config(key='name')
-        'Generic PANOPTES Unit'
+        'Testing PANOPTES Unit'
+
         >>> get_config(key='location.horizon')
         <Quantity 30. deg>
+
         >>> get_config(key='location.horizon', parse=False)
         '30.0 deg'
         >>> get_config(key='cameras.devices[1].model')
         'canon_gphoto2'
+
         >>> # Returns `None` if key is not found.
         >>> foobar = get_config(key='foobar')
         >>> foobar is None
         True
+
         >>> # But you can supply a default.
         >>> get_config(key='foobar', default='baz')
         'baz'
+
         >>> # Can use Quantities as well
         >>> from astropy import units as u
         >>> get_config(key='foobar', default=42 * u.meter)
@@ -79,11 +87,16 @@ def set_config(key, new_value, host='localhost', port='6563', parse=True):
     for details.
 
     Examples:
+
+    .. doctest::
+
         >>> from astropy import units as u
         >>> set_config('location.horizon', 35 * u.degree)
         {'location.horizon': <Quantity 35. deg>}
+
         >>> get_config(key='location.horizon')
         <Quantity 35. deg>
+
         >>> set_config('location.horizon', 30 * u.degree)
         {'location.horizon': <Quantity 30. deg>}
 

--- a/src/panoptes/utils/config/client.py
+++ b/src/panoptes/utils/config/client.py
@@ -54,17 +54,16 @@ def get_config(key=None, host='localhost', port='6563', parse=True, default=None
 
     try:
         response = requests.post(url, json={'key': key})
+        if not response.ok:  # pragma: no cover
+            logger.warning(f'Problem with get_config: {response.content!r}')
     except Exception as e:
-        logger.info(f'Problem with get_config: {e!r}')
+        logger.warning(f'Problem with get_config: {e!r}')
     else:
-        if not response.ok:
-            logger.info(f'Problem with get_config: {response.content!r}')
-        else:
-            if response.text != 'null\n':
-                if parse:
-                    config_entry = from_json(response.content.decode('utf8'))
-                else:
-                    config_entry = response.json()
+        if response.text != 'null\n':
+            if parse:
+                config_entry = from_json(response.content.decode('utf8'))
+            else:
+                config_entry = response.json()
 
     if config_entry is None:
         config_entry = default
@@ -113,10 +112,10 @@ def set_config(key, new_value, host='localhost', port='6563', parse=True):
                                  data=json_str,
                                  headers={'Content-Type': 'application/json'}
                                  )
-        if not response.ok:
+        if not response.ok:  # pragma: no cover
             raise Exception(f'Cannot access config server: {response.text}')
     except Exception as e:
-        logger.info(f'Problem with set_config: {e!r}')
+        logger.warning(f'Problem with set_config: {e!r}')
     else:
         if parse:
             config_entry = from_json(response.content.decode('utf8'))

--- a/src/panoptes/utils/serializers.py
+++ b/src/panoptes/utils/serializers.py
@@ -55,25 +55,26 @@ def to_json(obj, filename=None, append=True, **kwargs):
     Astropy quantities will be converted to a dict: `{"value": val, "unit": unit}`.
 
     Examples:
-        .. doctest::
 
-            >>> from panoptes.utils.serializers import to_json
-            >>> from astropy import units as u
-            >>> config = { "name": "Mauna Loa", "elevation": 3397 * u.meter }
-            >>> to_json(config)
-            '{"name": "Mauna Loa", "elevation": "3397.0 m"}'
+    .. doctest::
 
-            >>> to_json({"numpy_array": np.arange(10)})
-            '{"numpy_array": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}'
+        >>> from panoptes.utils.serializers import to_json
+        >>> from astropy import units as u
+        >>> config = { "name": "Mauna Loa", "elevation": 3397 * u.meter }
+        >>> to_json(config)
+        '{"name": "Mauna Loa", "elevation": "3397.0 m"}'
 
-            >>> from panoptes.utils import current_time
-            >>> to_json({"current_time": current_time()})       # doctest: +SKIP
-            '{"current_time": "2019-04-08 22:19:28.402198"}'
+        >>> to_json({"numpy_array": np.arange(10)})
+        '{"numpy_array": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}'
+
+        >>> from panoptes.utils import current_time
+        >>> to_json({"current_time": current_time()})       # doctest: +SKIP
+        '{"current_time": "2019-04-08 22:19:28.402198"}'
 
     Args:
         obj (`object`): The object to be converted to JSON, usually a dict.
-        filename (str, optional): Path to file for saving.
-        append (bool, optional): Append to `filename`, default True. Setting
+        filename (`str`, optional): Path to file for saving.
+        append (`bool`, optional): Append to `filename`, default True. Setting
             False will clobber the file.
         **kwargs: Keyword arguments passed to `json.dumps`.
 
@@ -107,42 +108,42 @@ def from_json(msg):
 
     Examples:
 
-        .. doctest::
+    .. doctest::
 
-            >>> from panoptes.utils.serializers import from_json
-            >>> config_str = '{"name":"Mauna Loa","elevation":{"value":3397.0,"unit":"m"}}'
-            >>> from_json(config_str)
-            {'name': 'Mauna Loa', 'elevation': <Quantity 3397. m>}
+        >>> from panoptes.utils.serializers import from_json
+        >>> config_str = '{"name":"Mauna Loa","elevation":{"value":3397.0,"unit":"m"}}'
+        >>> from_json(config_str)
+        {'name': 'Mauna Loa', 'elevation': <Quantity 3397. m>}
 
-            # Invalid values will be returned as is.
-            >>> from_json('{"horizon":{"value":42.0,"unit":"degr"}}')
-            {'horizon': {'value': 42.0, 'unit': 'degr'}}
+        # Invalid values will be returned as is.
+        >>> from_json('{"horizon":{"value":42.0,"unit":"degr"}}')
+        {'horizon': {'value': 42.0, 'unit': 'degr'}}
 
-            # The following will convert if final string:
-            >>> from_json('{"horizon": "42.0 deg"}')
-            {'horizon': <Quantity 42. deg>}
+        # The following will convert if final string:
+        >>> from_json('{"horizon": "42.0 deg"}')
+        {'horizon': <Quantity 42. deg>}
 
-            >>> from_json('{"elevation": "1000 m"}')
-            {'elevation': <Quantity 1000. m>}
+        >>> from_json('{"elevation": "1000 m"}')
+        {'elevation': <Quantity 1000. m>}
 
-            >>> from_json('{"readout_time": "10 s"}')
-            {'readout_time': <Quantity 10. s>}
+        >>> from_json('{"readout_time": "10 s"}')
+        {'readout_time': <Quantity 10. s>}
 
-            # Be careful with short unit names in extended format!
-            >>> horizon = from_json('{"horizon":{"value":42.0,"unit":"d"}}')
-            >>> horizon['horizon']
-            <Quantity 42. d>
-            >>> horizon['horizon'].decompose()
-            <Quantity 3628800. s>
+        # Be careful with short unit names in extended format!
+        >>> horizon = from_json('{"horizon":{"value":42.0,"unit":"d"}}')
+        >>> horizon['horizon']
+        <Quantity 42. d>
+        >>> horizon['horizon'].decompose()
+        <Quantity 3628800. s>
 
-            >>> from panoptes.utils import current_time
-            >>> time_str = to_json({"current_time": current_time().datetime})
-            >>> from_json(time_str)['current_time']         # doctest: +SKIP
-            2019-04-08T06:43:28.232406
+        >>> from panoptes.utils import current_time
+        >>> time_str = to_json({"current_time": current_time().datetime})
+        >>> from_json(time_str)['current_time']         # doctest: +SKIP
+        2019-04-08T06:43:28.232406
 
-            >>> from astropy.time import Time
-            >>> Time(from_json(time_str)['current_time'])   # doctest: +SKIP
-            <Time object: scale='utc' format='isot' value=2019-04-08T06:43:28.232>
+        >>> from astropy.time import Time
+        >>> Time(from_json(time_str)['current_time'])   # doctest: +SKIP
+        <Time object: scale='utc' format='isot' value=2019-04-08T06:43:28.232>
 
     Args:
         msg (`str`): The JSON string representation of the object.
@@ -170,28 +171,28 @@ def to_yaml(obj, **kwargs):
     Examples:
         Also see the examples `from_yaml`.
 
-        .. doctest::
+    .. doctest::
 
-            >>> import os
-            >>> os.environ['POCSTIME'] = '1999-12-31 23:49:49'
-            >>> from panoptes.utils import current_time
-            >>> t0 = current_time()
-            >>> t0
-            <Time object: scale='utc' format='iso' value=1999-12-31 23:49:49.000>
+        >>> import os
+        >>> os.environ['POCSTIME'] = '1999-12-31 23:49:49'
+        >>> from panoptes.utils import current_time
+        >>> t0 = current_time()
+        >>> t0
+        <Time object: scale='utc' format='iso' value=1999-12-31 23:49:49.000>
 
-            >>> to_yaml({'astropy time -> astropy time': t0})
-            "astropy time -> astropy time: '1999-12-31T23:49:49.000'\\n"
+        >>> to_yaml({'astropy time -> astropy time': t0})
+        "astropy time -> astropy time: '1999-12-31T23:49:49.000'\\n"
 
-            >>> to_yaml({'datetime -> astropy time': t0.datetime})
-            "datetime -> astropy time: '1999-12-31T23:49:49.000'\\n"
+        >>> to_yaml({'datetime -> astropy time': t0.datetime})
+        "datetime -> astropy time: '1999-12-31T23:49:49.000'\\n"
 
-            >>> # Can pass a `stream` parameter to save to file
-            >>> with open('temp.yaml', 'w') as f:           # doctest: +SKIP
-            ...     to_yaml({'my_object': 42}, stream=f)
+        >>> # Can pass a `stream` parameter to save to file
+        >>> with open('temp.yaml', 'w') as f:           # doctest: +SKIP
+        ...     to_yaml({'my_object': 42}, stream=f)
 
 
     Args:
-        obj (`object`): The object to be converted to be serialized.
+        obj (`dict`): The object to be converted to be serialized.
         **kwargs: Arguments passed to `ruamel.yaml.dump`. See Examples.
 
 
@@ -221,7 +222,7 @@ def from_yaml(msg, parse=True):
 
     .. doctest::
 
-        >>> config_str = '''name: Generic PANOPTES Unit
+        >>> config_str = '''name: Testing PANOPTES Unit
         ... pan_id: PAN000
         ...
         ... location:
@@ -236,7 +237,7 @@ def from_yaml(msg, parse=True):
 
         >>> yaml_config = to_yaml(config)
         >>> yaml_config                  # doctest: +SKIP
-        ''' name: Generic PANOPTES Unit
+        ''' name: Testing PANOPTES Unit
         ... pan_id: PAN000  # CHANGE NAME
         ...
         ... location:
@@ -279,7 +280,7 @@ def parse_all_objects(obj):
         See the `to/from_json/yaml` methods, which use this function.
 
     Args:
-        obj (`dict`): Object to check for quantities.
+        obj (`dict` or `str` or `object`): Object to check for quantities.
 
     Returns:
         `dict`: Same as `obj` but with objects converted to quantities.

--- a/src/panoptes/utils/serializers.py
+++ b/src/panoptes/utils/serializers.py
@@ -336,7 +336,7 @@ def serialize_object(obj):
 
     >>> dt0 = pendulum.parse('1999-12-31')
     >>> type(dt0)
-    pendulum.datetime.DateTime
+     <class 'pendulum.datetime.DateTime'>
     >>> serialize_object(dt0)
     '1999-12-31T00:00:00.000'
 

--- a/src/panoptes/utils/serializers.py
+++ b/src/panoptes/utils/serializers.py
@@ -270,10 +270,14 @@ def parse_all_objects(obj):
 
     This will currently attempt to parse and return, in the following order:
 
-    * If ``obj`` is a dict with exactly two keys named ``unit`` and ``value``, then attempt to parse into a valid ``astropy.unit.Quantity``.
-    * A boolean.
-    * A `datetime.datetime` object as parsed by `pendulum.parse`.
-    * If a string ending with any of ``['m', 'deg', 's']``, an ``astropy.unit.Quantity``
+    If ``obj`` is a dict with exactly two keys named ``unit`` and ``value``,
+    then attempt to parse into a valid ``astropy.unit.Quantity``.
+
+    A boolean.
+
+    A `datetime.datetime` object as parsed by `pendulum.parse`.
+
+    If a string ending with any of ``['m', 'deg', 's']``, an ``astropy.unit.Quantity``
 
     .. note::
 
@@ -318,10 +322,23 @@ def parse_all_objects(obj):
     return obj
 
 
-def serialize_object(obj, default_type=None):
+def serialize_object(obj):
     """Serialize the given object.
 
     This is a custom serializer function.
+
+    >>> from panoptes.utils.serializers import serialize_object
+    >>> import pendulum
+    >>> from astropy import units as u
+
+    >>> serialize_object(42 * u.meter)
+    '42.0 m'
+
+    >>> dt0 = pendulum.parse('1999-12-31')
+    >>> type(dt0)
+    pendulum.datetime.DateTime
+    >>> serialize_object(dt0)
+    '1999-12-31T00:00:00.000'
 
     .. note::
 
@@ -329,8 +346,6 @@ def serialize_object(obj, default_type=None):
 
     Args:
         obj (any): The object to be serialized.
-        default_type: The object to return as the default if no other
-            serialization was performed.
 
     Returns:
 
@@ -347,10 +362,6 @@ def serialize_object(obj, default_type=None):
     # Numpy array.
     if isinstance(obj, np.ndarray):
         return obj.tolist()
-
-    # If we are given a default object type, e.g. str
-    if default_type is not None:
-        return default_type(obj)
 
     # Exceptions - if not a class object, then `issubclass` raises a `TypeError`,
     # so we ignore those and let the object pass through.
@@ -379,6 +390,6 @@ def serialize_all_objects(obj):
         if isinstance(v, dict):
             obj[k] = serialize_all_objects(v)
         else:
-            obj[k] = serialize_object(v, default_type=None)
+            obj[k] = serialize_object(v)
 
     return obj

--- a/tests/test_config_server.py
+++ b/tests/test_config_server.py
@@ -8,43 +8,44 @@ from panoptes.utils.config.client import get_config
 from panoptes.utils.config.client import set_config
 
 
-def test_config_client(dynamic_config_server, config_port):
-    assert isinstance(get_config(port=config_port), dict)
+def test_config_client():
+    assert isinstance(get_config(), dict)
 
-    assert set_config('location.horizon', 47 * u.degree,
-                      port=config_port) == {'location.horizon': 47 * u.degree}
+    assert set_config('location.horizon', 47 * u.degree) == {'location.horizon': 47 * u.degree}
 
     # With parsing
-    assert get_config('location.horizon', port=config_port) == 47 * u.degree
+    assert get_config('location.horizon') == 47 * u.degree
 
     # Without parsing
-    assert get_config('location.horizon', port=config_port, parse=False) == '47.0 deg'
+    assert get_config('location.horizon', parse=False) == '47.0 deg'
 
 
-def test_config_client_bad(dynamic_config_server, config_port, caplog):
+def test_config_client_bad(caplog):
     # Bad host will return `None` but also throw error
     assert set_config('foo', 42, host='foobaz') is None
-    assert caplog.records[-1].levelname == "INFO"
+    assert caplog.records[-1].levelname == "WARNING"
     assert caplog.records[-1].message.startswith("Problem with set_config")
 
     # Bad host will return `None` but also throw error
     assert get_config('foo', host='foobaz') is None
-    assert caplog.records[-1].levelname == "INFO"
+    assert caplog.records[-1].levelname == "WARNING"
     assert caplog.records[-1].message.startswith("Problem with get_config")
 
 
-def test_config_reset(dynamic_config_server, config_port, config_host):
-    # Check we are at default.
-    assert get_config('location.horizon', port=config_port) == 30 * u.degree
+def test_config_reset():
+    # Check we are at value from above.
+    assert get_config('location.horizon') == 47 * u.degree
 
     # Set to new value.
-    set_config_return = set_config('location.horizon', 47 * u.degree, port=config_port)
-    assert set_config_return == {'location.horizon': 47 * u.degree}
+    set_config_return = set_config('location.horizon', 3 * u.degree)
+    assert set_config_return == {'location.horizon': 3 * u.degree}
 
     # Check we have changed.
-    assert get_config('location.horizon', port=config_port) == 47 * u.degree
+    assert get_config('location.horizon') == 3 * u.degree
 
     # Reset config
+    config_host = 'localhost'
+    config_port = 6563
     url = f'http://{config_host}:{config_port}/reset-config'
     response = requests.post(url,
                              data=serializers.to_json({'reset': True}),
@@ -53,4 +54,4 @@ def test_config_reset(dynamic_config_server, config_port, config_host):
     assert response.ok
 
     # Check we are at default again.
-    assert get_config('location.horizon', port=config_port) == 30 * u.degree
+    assert get_config('location.horizon') == 30 * u.degree

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -10,7 +10,7 @@ from panoptes.utils import error
 @pytest.fixture(scope='function')
 def obj():
     return {
-        "name": "Generic PANOPTES Unit",
+        "name": "Testing PANOPTES Unit",
         "pan_id": "PAN000",
         "location": {
             "name": "Mauna Loa Observatory",


### PR DESCRIPTION
 * Cleaning up the config_server.
  * Better logging.
  * Cleaning up doctests.
  * Removing all dynamic server items from this repo as they are not needed.
  * Wait for config_server to start.
  * Fixing starting within fixture.

* Serializers update
  * Make the parsing and serializing functions public.
  * Use pendulum for parsing times instead of astropy Time.

Closes #110 
Closes #111 