### PR TITLE
Config and serializer changes.

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,0 +1,2 @@
+ignore:
+  - "tests"

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,3 +1,2 @@
-codecov:
-  ignore:
-    - "tests/**/*.py"
+ignore:
+  - "tests/**/*.py"

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,2 +1,2 @@
 ignore:
-  - "tests/**/*.py"
+  - "tests/**/test_*.py"

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,2 +1,3 @@
-ignore:
-  - "tests"
+codecov:
+  ignore:
+    - "tests/**/*.py"

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -36,14 +36,13 @@ jobs:
           docker build -t panoptes-utils:develop -f docker/develop.Dockerfile .
       - name: Test with pytest in panoptes-utils container
         run: |
-          mkdir -p output_dir
-          chmod 777 output_dir
+          mkdir -p coverage_dir && chmod 777 coverage_dir
           ci_env=`bash <(curl -s https://codecov.io/env)`
           docker run -i \
             $ci_env \
             --network "host" \
-            -v $PWD/output_dir:/var/panoptes/logs \
-            -v $PWD/output_dir:/var/panoptes/panoptes-utils/build \
+            -v $PWD/coverage_dir:/var/panoptes/logs \
+            -v $PWD/coverage_dir:/var/panoptes/panoptes-utils/build/ \
             panoptes-utils:develop \
             scripts/testing/run-tests.sh
       - name: Upload coverage report to codecov.io
@@ -51,11 +50,11 @@ jobs:
         if: success()
         with:
           name: codecov-upload
-          file: output_dir/coverage.xml
+          file: coverage_dir/coverage.xml
           fail_ci_if_error: true
       - name: Create log file artifact
         uses: actions/upload-artifact@v1
         if: always()
         with:
           name: log-files
-          path: output_dir/panoptes-testing.log
+          path: coverage_dir/panoptes-testing.log

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -44,7 +44,7 @@ jobs:
             -v $PWD/coverage_dir:/var/panoptes/logs \
             -v $PWD/coverage_dir:/var/panoptes/panoptes-utils/build/ \
             panoptes-utils:develop \
-            scripts/testing/run-tests.sh
+            /var/panoptes/panoptes-utils/scripts/testing/run-tests.sh
       - name: Upload coverage report to codecov.io
         uses: codecov/codecov-action@v1
         if: success()

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -36,14 +36,14 @@ jobs:
           docker build -t panoptes-utils:develop -f docker/develop.Dockerfile .
       - name: Test with pytest in panoptes-utils container
         run: |
-          mkdir -p coverage_dir && chmod 777 coverage_dir
+          mkdir -p build && chmod 777 build
           ci_env=`bash <(curl -s https://codecov.io/env)`
           docker run -i \
             $ci_env \
             -e REPORT_FILE="/tmp/coverage/coverage.xml" \
             --network "host" \
-            -v $PWD/coverage_dir:/var/panoptes/logs \
-            -v $PWD/coverage_dir:/tmp/coverage \
+            -v $PWD/build:/var/panoptes/logs \
+            -v $PWD/build:/tmp/coverage \
             panoptes-utils:develop \
             scripts/testing/run-tests.sh
       - name: Upload coverage report to codecov.io
@@ -51,11 +51,11 @@ jobs:
         if: success()
         with:
           name: codecov-upload
-          file: coverage_dir/coverage.xml
+          file: build/coverage.xml
           fail_ci_if_error: true
       - name: Create log file artifact
         uses: actions/upload-artifact@v1
         if: always()
         with:
           name: log-files
-          path: coverage_dir/panoptes-testing.log
+          path: build/panoptes-testing.log

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -36,25 +36,25 @@ jobs:
           docker build -t panoptes-utils:develop -f docker/develop.Dockerfile .
       - name: Test with pytest in panoptes-utils container
         run: |
-          mkdir -p coverage_dir && chmod 777 coverage_dir
+          mkdir -p build && chmod 777 build
           ci_env=`bash <(curl -s https://codecov.io/env)`
           docker run -i \
             $ci_env \
             --network "host" \
-            -v $PWD/coverage_dir:/var/panoptes/logs \
-            -v $PWD/coverage_dir:/var/panoptes/panoptes-utils/build/ \
+            -v $PWD/build:/var/panoptes/logs \
+            -v $PWD/build:/var/panoptes/panoptes-utils/build/ \
             panoptes-utils:develop \
-            /var/panoptes/panoptes-utils/scripts/testing/run-tests.sh
+            scripts/testing/run-tests.sh
       - name: Upload coverage report to codecov.io
         uses: codecov/codecov-action@v1
         if: success()
         with:
           name: codecov-upload
-          file: coverage_dir/coverage.xml
+          file: build/coverage.xml
           fail_ci_if_error: true
       - name: Create log file artifact
         uses: actions/upload-artifact@v1
         if: always()
         with:
           name: log-files
-          path: coverage_dir/panoptes-testing.log
+          path: build/panoptes-testing.log

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -36,7 +36,8 @@ jobs:
           docker build -t panoptes-utils:develop -f docker/develop.Dockerfile .
       - name: Test with pytest in panoptes-utils container
         run: |
-          mkdir -p output_dir && chmod 777 output_dir
+          mkdir -p output_dir
+          chmod 777 output_dir
           ci_env=`bash <(curl -s https://codecov.io/env)`
           docker run -i \
             $ci_env \

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -41,7 +41,7 @@ jobs:
           docker run -i \
             $ci_env \
             --network "host" \
-            -v $PWD/build:build \
+            -v $PWD/build:/var/panoptes/panoptes-utils/build \
             panoptes-utils:develop \
             scripts/testing/run-tests.sh
       - name: Upload coverage report to codecov.io

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -36,7 +36,6 @@ jobs:
           docker build -t panoptes-utils:develop -f docker/develop.Dockerfile .
       - name: Test with pytest in panoptes-utils container
         run: |
-          mkdir -p build && chmod 777 build
           ci_env=`bash <(curl -s https://codecov.io/env)`
           docker run -i \
             $ci_env \

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -36,6 +36,7 @@ jobs:
           docker build -t panoptes-utils:develop -f docker/develop.Dockerfile .
       - name: Test with pytest in panoptes-utils container
         run: |
+          mkdir -p build && chmod 777 build
           ci_env=`bash <(curl -s https://codecov.io/env)`
           docker run -i \
             $ci_env \

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -40,10 +40,8 @@ jobs:
           ci_env=`bash <(curl -s https://codecov.io/env)`
           docker run -i \
             $ci_env \
-            -e REPORT_FILE="/tmp/coverage/coverage.xml" \
             --network "host" \
-            -v $PWD/build:/var/panoptes/logs \
-            -v $PWD/build:/tmp/coverage \
+            -v $PWD/build:build \
             panoptes-utils:develop \
             scripts/testing/run-tests.sh
       - name: Upload coverage report to codecov.io

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -43,7 +43,7 @@ jobs:
             $ci_env \
             --network "host" \
             -v $PWD/output_dir:/var/panoptes/logs \
-            -v $PWD/output_dir:/tmp/coverage \
+            -v $PWD/output_dir:/var/panoptes/panoptes-utils/build \
             panoptes-utils:develop \
             scripts/testing/run-tests.sh
       - name: Upload coverage report to codecov.io

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -36,11 +36,13 @@ jobs:
           docker build -t panoptes-utils:develop -f docker/develop.Dockerfile .
       - name: Test with pytest in panoptes-utils container
         run: |
+          mkdir -p output_dir && chmod 777 output_dir
           ci_env=`bash <(curl -s https://codecov.io/env)`
           docker run -i \
             $ci_env \
             --network "host" \
-            -v $PWD/build:/var/panoptes/panoptes-utils/build \
+            -v $PWD/output_dir:/var/panoptes/logs \
+            -v $PWD/output_dir:/tmp/coverage \
             panoptes-utils:develop \
             scripts/testing/run-tests.sh
       - name: Upload coverage report to codecov.io
@@ -48,11 +50,11 @@ jobs:
         if: success()
         with:
           name: codecov-upload
-          file: build/coverage.xml
+          file: output_dir/coverage.xml
           fail_ci_if_error: true
       - name: Create log file artifact
         uses: actions/upload-artifact@v1
         if: always()
         with:
           name: log-files
-          path: build/panoptes-testing.log
+          path: output_dir/panoptes-testing.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install: true
 script:
   - docker run -it
     panoptes-utils:develop
-    /var/panoptes/panoptes-utils/scripts/testing/run-tests.sh
+    scripts/testing/run-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install: true
 script:
   - docker run -it
     panoptes-utils:develop
-    scripts/testing/run-tests.sh
+    /var/panoptes/panoptes-utils/scripts/testing/run-tests.sh

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,16 +9,25 @@ Changed
 ^^^^^^^
 
 * Python minimum version changed to ``3.8``. (#217)
+* Running pytest locally will generate coverage report in terminal. (#218)
+* Lots of documentation. (#218)
+* Removing the environment section from the readme. (#218)
 * Cleaning up the config_server. (#217)
     * Better logging.
     * Cleaning up doctests.
     * Removing all dynamic server items from this repo as they are not needed.
     * Wait for config_server to start.
     * Fixing starting within fixture.
+    * Config items no longer assume any defaults for either directories or files. A config file name is always required and it should always be an absolute path. (#218)
+    * Adding test file for config items. (#218)
 
+* Testing
+    * Log files are rotated for each testing run. (#218)
+    * Fix env vars (mostly need to make sure the `export` option exists in the `env` file. (#218)
 * Serializers update. (#217)
     * Make the parsing and serializing functions public.
     * Use pendulum for parsing times instead of astropy Time.
+    * Better naming of public functions. (#218)
 
 
 0.2.19 - 2020-06-04

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,21 +13,31 @@ Changed
 * Lots of documentation. (#218)
 * Removing the environment section from the readme. (#218)
 * Cleaning up the config_server. (#217)
-    * Better logging.
-    * Cleaning up doctests.
-    * Removing all dynamic server items from this repo as they are not needed.
-    * Wait for config_server to start.
-    * Fixing starting within fixture.
-    * Config items no longer assume any defaults for either directories or files. A config file name is always required and it should always be an absolute path. (#218)
-    * Adding test file for config items. (#218)
 
-* Testing
-    * Log files are rotated for each testing run. (#218)
-    * Fix env vars (mostly need to make sure the `export` option exists in the `env` file. (#218)
+  * Better logging.
+  * Cleaning up doctests.
+  * Removing all dynamic server items from this repo as they are not needed.
+  * Wait for config_server to start.
+  * Fixing starting within fixture.
+  * Config items no longer assume any defaults for either directories or files. A config file name is always required and it should always be an absolute path. (#218)
+  * Adding test file for config items. (#218)
+
+* Testing (#218)
+
+  * Log files are rotated for each testing run.
+  * Fix env vars (mostly need to make sure the `export` option exists in the `env` file.
+  * Pytest commands moved to `setup.cfg` instead of `run-tests.sh`
+  * Remove old markers
+  * Setting `--strict-markers` options.
+  * Add `astrometry` marker for tests requiring solve and `theskyx` marker for running alongside TheSkyX.
+  * Coverage reports generated in xml and html.
+  * Coverage output goes to `build` dir.
+
 * Serializers update. (#217)
-    * Make the parsing and serializing functions public.
-    * Use pendulum for parsing times instead of astropy Time.
-    * Better naming of public functions. (#218)
+
+  * Make the parsing and serializing functions public.
+  * Use pendulum for parsing times instead of astropy Time.
+  * Better naming of public functions. (#218)
 
 
 0.2.19 - 2020-06-04

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Changelog
 Changed
 ^^^^^^^
 
-* Python minimum version changed to ``3.8``. (#217)
+* **Breaking** Python minimum version changed to ``3.8``. (#217)
 * Running pytest locally will generate coverage report in terminal. (#218)
 * Lots of documentation. (#218)
 * Removing the environment section from the readme. (#218)

--- a/conftest.py
+++ b/conftest.py
@@ -32,14 +32,18 @@ log_fmt = "<lvl>{level:.1s}</lvl> " \
           "<blue>({time:HH:mm:ss.ss})</> " \
           "| <c>{name} {function}:{line}</c> | " \
           "<lvl>{message}</lvl>\n"
+
+startup_message = ' STARTING NEW PYTEST RUN '
 logger.add(log_file_path,
            enqueue=True,  # multiprocessing
            format=log_fmt,
            colorize=True,
            backtrace=True,
            diagnose=True,
+           # Start new log file for each testing run.
+           rotation=lambda msg, _: startup_message in msg,
            level='TRACE')
-logger.log('testing', '*' * 25 + ' STARTING NEW PYTEST RUN ' + '*' * 25)
+logger.log('testing', '*' * 25 + startup_message + '*' * 25)
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -50,27 +50,10 @@ def pytest_addoption(parser):
     db_names = ",".join(_all_databases) + ' (or all for all databases)'
     group = parser.getgroup("PANOPTES pytest options")
     group.addoption(
-        "--with-hardware",
-        nargs='+',
-        default=[],
-        help="A comma separated list of hardware to test.")
-    group.addoption(
-        "--without-hardware",
-        nargs='+',
-        default=[],
-        help="A comma separated list of hardware to NOT test. ")
-    group.addoption(
-        "--solve",
+        "--astrometry",
         action="store_true",
         default=False,
         help="If tests that require solving should be run")
-    group.addoption(
-        "--test-cloud-storage",
-        action="store_true",
-        default=False,
-        dest="test_cloud_storage",
-        help="Tests cloud storage functions." +
-             "Requires $PANOPTES_CLOUD_KEY to be set to path of valid json service key")
     group.addoption(
         "--test-databases",
         nargs="+",

--- a/conftest.py
+++ b/conftest.py
@@ -55,6 +55,11 @@ def pytest_addoption(parser):
         default=False,
         help="If tests that require solving should be run")
     group.addoption(
+        "--theskyx",
+        action="store_true",
+        default=False,
+        help="If running tests alongside a running TheSkyX program.")
+    group.addoption(
         "--test-databases",
         nargs="+",
         default=['file'],

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -88,7 +88,7 @@ Or inside a python process:
 
     >>> server_process.terminate()  # Or just exit notebook/console
 
-For more details and usage examples, see the Config Server.
+For more details and usage examples, see the :ref:`config-server`.
 
 Development
 ===========
@@ -96,30 +96,8 @@ Development
 Environment
 -----------
 
-There is a docker development environment that has a number of support
-modules installed. This also defaults to running a ``jupyter-lab``
-instance with the ``$PANDIR`` folder as the root.
-
-You should have all ``panoptes`` repositories for development (maybe
-``POCS``, ``panoptes-utils``, ``panoptes-tutorials``) inside the
-``$PANDIR`` folder (default ``/var/panoptes``). Ideally you have just
-run the install script at **TODO: reference install script here.**.
-
-You can then start the development environment by:
-
-.. code:: sh
-
-   bin/panoptes-develop up
-
-You can then connect to the provided url in your browser. The default
-password is ``panoptes``, which is not supplied for security purposes
-but just to allow access.
-
-The environment can be stopped with:
-
-.. code:: sh
-
-   bin/panoptes-develop down
+Most users of ``panoptes-utils`` who need the full environment will also
+want the fulle `POCS Environment`_.
 
 Logging
 -------
@@ -198,6 +176,7 @@ Indices and tables
 .. _services: #services
 .. _loguru: https://github.com/Delgan/loguru
 .. _Logger: #logger
+.. _POCS Environment: https://pocs.readthedocs.io/en/latest/#pocs-environment
 
 .. |PyPI version| image:: https://badge.fury.io/py/panoptes-utils.svg
    :target: https://badge.fury.io/py/panoptes-utils

--- a/scripts/testing/run-tests.sh
+++ b/scripts/testing/run-tests.sh
@@ -1,6 +1,4 @@
-#!/bin/bash -e
-
-REPORT_FILE=${REPORT_FILE:-build/coverage.xml}
+#!/usr/bin/bash
 
 export PYTHONPATH="${PYTHONPATH}:${PANDIR}/panoptes-utils/scripts/testing/coverage"
 export COVERAGE_PROCESS_START="${PANDIR}/panoptes-utils/setup.cfg"
@@ -10,11 +8,5 @@ coverage erase
 # Run coverage over the pytest suite
 echo "Starting tests"
 coverage run "$(command -v pytest)"
-
-echo "Combining coverage"
-coverage combine
-
-echo "Making XML coverage report at ${REPORT_FILE}"
-coverage xml -o "${REPORT_FILE}"
 
 exit 0

--- a/scripts/testing/run-tests.sh
+++ b/scripts/testing/run-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-export PYTHONPATH="${PYTHONPATH}:${PANDIR}/panoptes-utils/scripts/testing/coverage"
-export COVERAGE_PROCESS_START="${PANDIR}/panoptes-utils/setup.cfg"
+export PYTHONPATH="${PYTHONPATH}:/var/panoptes/panoptes-utils/scripts/testing/coverage"
+export COVERAGE_PROCESS_START="/var/panoptes/panoptes-utils/setup.cfg"
 
 coverage erase
 

--- a/scripts/testing/run-tests.sh
+++ b/scripts/testing/run-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash -e
 
 export PYTHONPATH="${PYTHONPATH}:${PANDIR}/panoptes-utils/scripts/testing/coverage"
 export COVERAGE_PROCESS_START="${PANDIR}/panoptes-utils/setup.cfg"

--- a/scripts/testing/run-tests.sh
+++ b/scripts/testing/run-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-REPORT_FILE=${REPORT_FILE:-coverage.xml}
+REPORT_FILE=${REPORT_FILE:-build/coverage.xml}
 
 export PYTHONPATH="${PYTHONPATH}:${PANDIR}/panoptes-utils/scripts/testing/coverage"
 export COVERAGE_PROCESS_START="${PANDIR}/panoptes-utils/setup.cfg"
@@ -9,7 +9,7 @@ coverage erase
 
 # Run coverage over the pytest suite
 echo "Starting tests"
-coverage run "$(command -v pytest)" -x -vv -rfes --test-databases all
+coverage run "$(command -v pytest)"
 
 echo "Combining coverage"
 coverage combine

--- a/scripts/testing/run-tests.sh
+++ b/scripts/testing/run-tests.sh
@@ -2,8 +2,8 @@
 
 REPORT_FILE=${REPORT_FILE:-coverage.xml}
 
-export PYTHONPATH="${PYTHONPATH}:/var/panoptes/panoptes-utils/scripts/testing/coverage"
-export COVERAGE_PROCESS_START="/var/panoptes/panoptes-utils/setup.cfg"
+export PYTHONPATH="${PYTHONPATH}:${PANDIR}/panoptes-utils/scripts/testing/coverage"
+export COVERAGE_PROCESS_START="${PANDIR}/panoptes-utils/setup.cfg"
 
 coverage erase
 

--- a/scripts/testing/test-software.sh
+++ b/scripts/testing/test-software.sh
@@ -14,6 +14,8 @@ You can view the output for the tests in a separate terminal:
 tail -F ${PANDIR}/logs/panoptes-testing.log
 
 Tests will begin in 5 seconds. Press Ctrl-c to cancel.
+
+The coverage report will open in your browser when the tests are complete.
 EOF
 
 sleep 5;
@@ -24,3 +26,5 @@ docker run --rm -it \
     panoptes-utils:develop \
     "${PANDIR}/panoptes-utils/scripts/testing/run-tests.sh"
 
+# Open the report.
+xdg-open build/htmlcov/index.html

--- a/scripts/testing/test-software.sh
+++ b/scripts/testing/test-software.sh
@@ -1,19 +1,17 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
 clear;
 
-cat << EOF
+cat <<EOF
 Beginning test of panoptes-utils software. This software is run inside a virtualized docker
 container that has all of the required dependencies installed.
 
-This will start a single docker container, mapping the host $PANDIR into the running docker
+This will start a single docker container, mapping the host PANDIR=${PANDIR} into the running docker
 container, which allows for testing of any local changes.
 
 You can view the output for the tests in a separate terminal:
 
-grc tail -F ${PANDIR}/log/pytest-all.log
-
-The tests will start by updating: ${PANDIR}/panoptes-utils/requirements.txt inside the container.
+tail -F ${PANDIR}/logs/panoptes-testing.log
 
 Tests will begin in 5 seconds. Press Ctrl-c to cancel.
 EOF
@@ -21,8 +19,8 @@ EOF
 sleep 5;
 
 docker run --rm -it \
-    -v /var/panoptes/panoptes-utils:/var/panoptes/panoptes-utils \
-    -v /var/panoptes/logs:/var/panoptes/logs \
+    -v "${PANDIR}/panoptes-utils":/var/panoptes/panoptes-utils \
+    -v "${PANDIR}/logs":/var/panoptes/logs \
     panoptes-utils:develop \
-    "/var/panoptes/panoptes-utils/scripts/testing/run-tests.sh"
+    "${PANDIR}/panoptes-utils/scripts/testing/run-tests.sh"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,7 @@ extras = True
 
 [tool:pytest]
 addopts =
+    --cov panoptes.utils --cov-report html
     --doctest-modules
     --test-databases all
     -x

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,6 @@ extras = True
 
 [tool:pytest]
 addopts =
-    --cov panoptes.utils --cov-report html --cov-report xml
     --doctest-modules
     --test-databases all
     --strict-markers

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,18 +8,20 @@ long-description = file: README.md
 long-description-content-type = text/markdown; charset=UTF-8
 url = https://github.com/panoptes/panoptes-utils
 project-urls =
-    Documentation = https://panoptes-utils.readthedocs.org
+    Documentation = https://panoptes-utils.readthedocs.io
+    POCS Documentation = https://pocs.readthedocs.io
+    Project PANOPTES = https://www.projectpanoptes.org
+    Forum = https://forum.projectpanoptes.org
 # Change if running only on Windows, Mac or Linux (comma-separated)
 platforms = linux
 # Add here all kinds of additional classifiers as defined under
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 4 - Beta
     Environment :: Console
     Intended Audience :: Science/Research
     License :: OSI Approved :: MIT License
     Operating System :: POSIX
-    Programming Language :: C
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3 :: Only
@@ -66,7 +68,7 @@ install_requires =
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.packages.find]
 where = src
@@ -98,11 +100,14 @@ extras = True
 
 [tool:pytest]
 addopts =
-    --cov panoptes.utils --cov-report html
+    --cov panoptes.utils --cov-report html --cov-report xml
     --doctest-modules
     --test-databases all
+    --strict-markers
+    --open-files
     -x
     -vv
+    -rst
 norecursedirs =
     script
     resources
@@ -115,6 +120,9 @@ filterwarnings =
     ignore:elementwise == comparison failed:DeprecationWarning
     ignore::pytest.PytestDeprecationWarning
 doctest_plus = enabled
+markers =
+    astrometry: tests that require astromery.net (i.e. solve-field)
+    slow: marks tests as slow (deselect with '-m "not slow"')
 
 [aliases]
 dists = bdist_wheel
@@ -145,21 +153,12 @@ exclude =
 [pycodestyle]
 max-line-length = 100
 
-[pyscaffold]
-# PyScaffold's parameters when the project was created.
-# This will be used when updating. Do not change!
-version = 3.2.3
-package = utils
-extensions =
-    no_skeleton
-    namespace
-namespace = panoptes
-
 [coverage:run]
 branch = True
 concurrency =
     multiprocessing
     subprocess
+    thread
     threading
 parallel = True
 
@@ -186,4 +185,21 @@ exclude_lines =
     if 0:
     if __name__ == .__main__.:
 
+show_missing = True
 ignore_errors = True
+
+[coverage:html]
+directory = 'build/htmlcov'
+
+[coverage:xml]
+output = 'build/coverage.xml'
+
+[pyscaffold]
+# PyScaffold's parameters when the project was created.
+# This will be used when updating. Do not change!
+version = 3.2.3
+package = utils
+extensions =
+    no_skeleton
+    namespace
+namespace = panoptes

--- a/setup.cfg
+++ b/setup.cfg
@@ -185,7 +185,10 @@ exclude_lines =
     if 0:
     if __name__ == .__main__.:
 
+show_missing = True
 ignore_errors = True
+omit =
+    tests/*
 
 [coverage:html]
 directory = build/htmlcov

--- a/setup.cfg
+++ b/setup.cfg
@@ -185,7 +185,6 @@ exclude_lines =
     if 0:
     if __name__ == .__main__.:
 
-show_missing = True
 ignore_errors = True
 
 [coverage:html]

--- a/setup.cfg
+++ b/setup.cfg
@@ -188,7 +188,7 @@ exclude_lines =
 show_missing = True
 ignore_errors = True
 omit =
-    tests/*
+    tests/
 
 [coverage:html]
 directory = build/htmlcov

--- a/setup.cfg
+++ b/setup.cfg
@@ -104,7 +104,6 @@ addopts =
     --doctest-modules
     --test-databases all
     --strict-markers
-    --open-files
     -x
     -vv
     -rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -120,8 +120,9 @@ filterwarnings =
     ignore::pytest.PytestDeprecationWarning
 doctest_plus = enabled
 markers =
-    astrometry: tests that require astromery.net (i.e. solve-field)
-    slow: marks tests as slow (deselect with '-m "not slow"')
+    astrometry: tests that require astromery.net (i.e. solve-field).
+    theskyx: tests that require TheSkyX to also be running.
+    slow: marks tests as slow (deselect with '-m "not slow"').
 
 [aliases]
 dists = bdist_wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,6 +100,7 @@ extras = True
 
 [tool:pytest]
 addopts =
+    --cov panoptes.utils --cov-report html --cov-report xml
     --doctest-modules
     --test-databases all
     --strict-markers

--- a/setup.cfg
+++ b/setup.cfg
@@ -189,10 +189,10 @@ show_missing = True
 ignore_errors = True
 
 [coverage:html]
-directory = 'build/htmlcov'
+directory = build/htmlcov
 
 [coverage:xml]
-output = 'build/coverage.xml'
+output = build/coverage.xml
 
 [pyscaffold]
 # PyScaffold's parameters when the project was created.

--- a/setup.cfg
+++ b/setup.cfg
@@ -159,6 +159,7 @@ namespace = panoptes
 branch = True
 concurrency =
     multiprocessing
+    subprocess
     threading
 parallel = True
 

--- a/src/panoptes/utils/config/client.py
+++ b/src/panoptes/utils/config/client.py
@@ -8,10 +8,10 @@ from ..serializers import to_json
 def get_config(key=None, host='localhost', port='6563', parse=True, default=None):
     """Get a config item from the config server.
 
-    Return the config entry for the given `key`. If `key=None` (default), return
+    Return the config entry for the given ``key``. If ``key=None`` (default), return
     the entire config.
 
-    Nested keys can be specified as a string, as per [scalpl](https://pypi.org/project/scalpl/).
+    Nested keys can be specified as a string, as per `scalpl <https://pypi.org/project/scalpl/>`_.
 
     Examples:
 
@@ -43,11 +43,11 @@ def get_config(key=None, host='localhost', port='6563', parse=True, default=None
         <Quantity 42. m>
 
     Args:
-        key (str): The key to update, see Examples in `get_config` for details.
+        key (str): The key to update, see Examples in :func:`get_config` for details.
         host (str, optional): The config server host, defaults to '127.0.0.1'.
         port (str, optional): The config server port, defaults to 6563.
         parse (bool, optional): If response should be parsed by
-            `~panoptes.utils.serializers.from_json`, default True.
+            :func:`panoptes.utils.serializers.from_json`, default True.
         default (str, optional): The config server port, defaults to 6563.
 
     Returns:
@@ -83,30 +83,33 @@ def set_config(key, new_value, host='localhost', port='6563', parse=True):
     """Set config item in config server.
 
     Given a `key` entry, update the config to match. The `key` is a dot accessible
-    string, as given by [scalpl](https://pypi.org/project/scalpl/). See Examples in `get_config`
-    for details.
+    string, as given by `scalpl <https://pypi.org/project/scalpl/>`_. See Examples in
+    :func:`get_config` for details.
 
     Examples:
 
     .. doctest::
 
         >>> from astropy import units as u
+
+        >>> # Can use astropy units.
         >>> set_config('location.horizon', 35 * u.degree)
         {'location.horizon': <Quantity 35. deg>}
 
         >>> get_config(key='location.horizon')
         <Quantity 35. deg>
 
-        >>> set_config('location.horizon', 30 * u.degree)
+        >>> # String equivalent works for 'deg', 'm', 's'.
+        >>> set_config('location.horizon', '30 deg')
         {'location.horizon': <Quantity 30. deg>}
 
     Args:
-        key (str): The key to update, see Examples in `get_config` for details.
+        key (str): The key to update, see Examples in :func:`get_config` for details.
         new_value (scalar|object): The new value for the key, can be any serializable object.
         host (str, optional): The config server host, defaults to '127.0.0.1'.
         port (str, optional): The config server port, defaults to 6563.
         parse (bool, optional): If response should be parsed by
-            `~panoptes.utils.serializers.from_json`, default True.
+            :func:`panoptes.utils.serializers.from_json`, default True.
 
     Returns:
         dict: The updated config entry.

--- a/src/panoptes/utils/config/server.py
+++ b/src/panoptes/utils/config/server.py
@@ -21,6 +21,15 @@ app = Flask(__name__)
 class CustomJSONEncoder(JSONEncoder):
 
     def default(self, obj):
+        """Custom serialization of each object.
+
+        This method will call :func:`panoptes.utils.serializers.serialize_object` for
+        each object.
+
+        Args:
+            obj (`any`): The object to serialize.
+
+        """
         return serialize_object(obj)
 
 
@@ -60,9 +69,9 @@ def run():  # pragma: no cover
         server_process.terminate()
 
 
-def config_server(host='localhost',
+def config_server(config_file,
+                  host='localhost',
                   port=6563,
-                  config_file=None,
                   ignore_local=False,
                   auto_save=False,
                   auto_start=True,
@@ -72,20 +81,16 @@ def config_server(host='localhost',
     A convenience function to start the config server.
 
     Args:
+        config_file (str): The absolute path to the config file to load.
         host (str, optional): Name of host, default 'localhost'.
         port (int, optional): Port for server, default 6563.
-        config_file (str|None, optional): The config file to load, defaults to
-            ``$PANDIR/conf_files/pocs.yaml``.
-        ignore_local (bool, optional): If local config files should be ignored,
-            default False.
-        auto_save (bool, optional): If setting new values should auto-save to
-            local file, default False.
-        auto_start (bool, optional): If server process should be started
-            automatically, default True.
+        ignore_local (bool, optional): If local config files should be ignored, default False.
+        auto_save (bool, optional): If setting new values should auto-save to local file, default False.
+        auto_start (bool, optional): If server process should be started automatically, default True.
         debug (bool, optional): Flask server debug mode, default False.
 
     Returns:
-        `multiprocessing.Process`: The process running the config server.
+        multiprocessing.Process: The process running the config server.
     """
     app.config['auto_save'] = auto_save
     app.config['config_file'] = config_file
@@ -118,28 +123,33 @@ def get_config_entry():
     configuration item corresponding to provided key or entire
     configuration. The key entries should be specified in dot-notation,
     with the names corresponding to the entries stored in the configuration
-    file. See the [scalpl](https://pypi.org/project/scalpl/) documentation
+    file. See the `scalpl <https://pypi.org/project/scalpl/>`_ documentation
     for details on the dot-notation.
 
-    The endpoint should received a JSON document with a single key named "key"
+    The endpoint should receive a JSON document with a single key named ``"key"``
     and a value that corresponds to the desired key within the configuration.
 
     For example, take the following configuration:
 
-    ..code::
+    .. code:: javascript
 
         {
             'location': {
                 'elevation': 3400.0,
+                'latitude': 19.55,
+                'longitude': 155.12,
             }
         }
 
     To get the corresponding value for the elevation, pass a JSON document similar to:
 
-    ..code::
+    .. code:: javascript
 
         '{"key": "location.elevation"}'
 
+    Returns:
+        str: The json string for the requested object if object is found in config.
+        Otherwise a json string with ``status`` and ``msg`` keys will be returned.
     """
     req_json = request.get_json()
 
@@ -170,6 +180,42 @@ def get_config_entry():
 
 @app.route('/set-config', methods=['GET', 'POST'])
 def set_config_entry():
+    """Sets an item in the config.
+
+    Endpoint that responds to GET and POST requests and sets a
+    configuration item corresponding to the provided key.
+
+    The key entries should be specified in dot-notation, with the names
+    corresponding to the entries stored in the configuration file. See
+    the `scalpl <https://pypi.org/project/scalpl/>`_ documentation for details
+    on the dot-notation.
+
+    The endpoint should receive a JSON document with a single key named ``"key"``
+    and a value that corresponds to the desired key within the configuration.
+
+    For example, take the following configuration:
+
+    .. code:: javascript
+
+        {
+            'location': {
+                'elevation': 3400.0,
+                'latitude': 19.55,
+                'longitude': 155.12,
+            }
+        }
+
+    To set the corresponding value for the elevation, pass a JSON document similar to:
+
+    .. code:: javascript
+
+        '{"location.elevation": "1000 m"}'
+
+
+    Returns:
+        str: If method is successful, returned json string will be a copy of the set values.
+        On failure, a json string with ``status`` and ``msg`` keys will be returned.
+    """
     if request.is_json:
         req_data = request.get_json()
 
@@ -195,6 +241,24 @@ def set_config_entry():
 
 @app.route('/reset-config', methods=['POST'])
 def reset_config():
+    """Reset the configuration.
+
+    An endpoint that accepts a POST method. The json request object
+    must contain the key ``reset`` (with any value).
+
+    The method will reset the configuration to the original configuration files that were
+    used, skipping the local (and saved file).
+
+    .. note::
+
+        If the server was originally started with a local version of the file, those will
+        be skipped upon reload. This is not ideal but hopefully this method is not used too
+        much.
+
+    Returns:
+        str: A json string object containing the keys ``success`` and ``msg`` that indicate
+        success or failure.
+    """
     if request.is_json:
         logger.warning(f'Resetting config server')
         req_data = request.get_json()
@@ -205,7 +269,10 @@ def reset_config():
                                              ignore_local=app.config['ignore_local'])
             app.config['POCS_cut'] = Cut(app.config['POCS'])
 
-        return jsonify(req_data)
+        return jsonify({
+            'success': True,
+            'msg': f'Configuration reset'
+        })
 
     return jsonify({
         'success': False,

--- a/tests/images/test_fits_utils.py
+++ b/tests/images/test_fits_utils.py
@@ -11,6 +11,7 @@ from panoptes.utils.images import fits as fits_utils
 from panoptes.utils import error
 
 
+@pytest.mark.astrometry
 def test_wcsinfo(solved_fits_file):
     wcsinfo = fits_utils.get_wcsinfo(solved_fits_file)
 
@@ -18,6 +19,7 @@ def test_wcsinfo(solved_fits_file):
     assert wcsinfo['ra_center'].value == pytest.approx(303.20, rel=1e-2)
 
 
+@pytest.mark.astrometry
 def test_fpack(solved_fits_file):
     new_file = solved_fits_file.replace('solved', 'solved_copy')
     copy_file = shutil.copyfile(solved_fits_file, new_file)
@@ -33,6 +35,7 @@ def test_fpack(solved_fits_file):
     os.remove(copy_file)
 
 
+@pytest.mark.astrometry
 def test_no_overwrite_fpack(solved_fits_file):
     new_file = solved_fits_file.replace('solved', 'solved_copy')
     copy_file = shutil.copyfile(solved_fits_file, new_file)
@@ -67,6 +70,7 @@ def test_getval(solved_fits_file):
     assert img_id == 'PAN001_XXXXXX_20160909T081152'
 
 
+@pytest.mark.astrometry
 def test_solve_field_unsolved(unsolved_fits_file):
     with pytest.raises(KeyError):
         fits_utils.getval(unsolved_fits_file, 'WCSAXES')
@@ -93,6 +97,7 @@ def test_solve_field_unsolved(unsolved_fits_file):
             os.remove(unsolved_fits_file.replace('.fits', ext))
 
 
+@pytest.mark.astrometry
 def test_get_solve_field_solved(solved_fits_file):
     orig_wcs = fits_utils.get_wcsinfo(solved_fits_file)
     assert 'crpix0' in orig_wcs
@@ -103,24 +108,13 @@ def test_get_solve_field_solved(solved_fits_file):
     assert 'CRPIX1' in solve_info
 
 
+@pytest.mark.astrometry
 def test_get_solve_field_timeout(unsolved_fits_file):
     with pytest.raises(error.Timeout):
         solve_info = fits_utils.get_solve_field(unsolved_fits_file, timeout=1)
 
 
-# def test_solve_options(unsolved_fits_file):
-#     proc = fits_utils.solve_field(
-#         unsolved_fits_file, solve_opts=['--cpulimit', '1'])
-#     assert isinstance(proc, subprocess.Popen)
-#     try:
-#         outs, errs = proc.communicate(timeout=15)
-#     except subprocess.TimeoutExpired:
-#         proc.kill()
-#         outs, errs = proc.communicate()
-#     # Timeout
-#     assert proc.returncode == 0
-
-
+@pytest.mark.astrometry
 def test_solve_bad_field():
     proc = fits_utils.solve_field('Foo.fits')
     outs, errs = proc.communicate()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,21 @@
+from panoptes.utils.serializers import to_yaml
+from panoptes.utils import config
+
+
+def test_load_config():
+    """Test basic loading"""
+    conf = config.load_config()
+    assert conf['name'] == 'Generic PANOPTES unit'
+
+
+def test_load_config_custom_file(tmp_path):
+    """Test with a custom file"""
+    temp_conf_text = to_yaml(dict(name='Temporary Name', location=dict(elevation=1234.56)))
+
+    temp_conf_file = tmp_path / 'temp_conf.yaml'
+    temp_conf_file.write_text(temp_conf_text)
+
+    temp_config = config.load_config(str(temp_conf_file.absolute()))
+    assert len(temp_config) == 2
+    assert temp_config['name'] == 'Temporary Name'
+    assert isinstance(temp_config['location'], dict)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,10 +2,10 @@ from panoptes.utils.serializers import to_yaml
 from panoptes.utils import config
 
 
-def test_load_config():
+def test_load_config(config_path):
     """Test basic loading"""
-    conf = config.load_config()
-    assert conf['name'] == 'Generic PANOPTES unit'
+    conf = config.load_config(config_files=config_path)
+    assert conf['name'] == 'Testing PANOPTES Unit'
 
 
 def test_load_config_custom_file(tmp_path):

--- a/tests/test_theskyx_utils.py
+++ b/tests/test_theskyx_utils.py
@@ -14,9 +14,9 @@ def skyx(data_dir, request):
     be disabled here.
     """
 
-    # Use `--with-hardware thesky` on cli to run without mock
+    # Use `--theskyx thesky` on cli to run without mock
     Mocket.enable('theskyx', data_dir)
-    if 'theskyx' in request.config.getoption('--with-hardware'):
+    if request.config.getoption('--theskyx'):
         Mocket.disable()
 
     theskyx = TheSkyX(connect=False)
@@ -30,8 +30,8 @@ def test_default_connect(data_dir, request):
 
     If not running with a real connection then use Mocket
     """
-    # Use `--with-hardware thesky` on cli to run without mock
-    if 'theskyx' not in request.config.getoption('--with-hardware'):
+    # Use `--theskyx thesky` on cli to run without mock
+    if not request.config.getoption('--theskyx'):
         Mocket.enable('theskyx', data_dir)
 
     skyx = TheSkyX()

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -89,6 +89,7 @@ def test_countdown_timer_sleep():
     assert timer.sleep() is False
 
 
+@pytest.mark.slow
 def test_wait_for_events():
     # Create some events, normally something like taking an image.
     event0 = threading.Event()


### PR DESCRIPTION
Config changes

* Config items no longer assume any defaults for either directories or files. A config file name is always required and it should always be an absolute path.
* Adding test file for config items.

Serializers:

* Better naming of public functions.

Misc:

* Running pytest locally will generate coverage report in terminal.
* Lots of documentation.
* Removing the environment section from the readme.

#217 
#111 
#110 