### PR TITLE
Custom DB folder.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -129,8 +129,11 @@ def db_type(request):
     if request.param not in db_list and 'all' not in db_list:  # pragma: no cover
         pytest.skip(f"Skipping {request.param} DB, set --test-all-databases=True")
 
-    PanDB.permanently_erase_database(
-        request.param, 'panoptes_testing', really='Yes', dangerous='Totally')
+    PanDB.permanently_erase_database(request.param,
+                                     'panoptes_testing',
+                                     storage_dir='testing',
+                                     really='Yes',
+                                     dangerous='Totally')
     return request.param
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -136,7 +136,7 @@ def db_type(request):
 
 @pytest.fixture(scope='function')
 def db(db_type):
-    return PanDB(db_type=db_type, db_name='panoptes_testing', connect=True)
+    return PanDB(db_type=db_type, db_name='panoptes_testing', storage_dir='testing', connect=True)
 
 
 @pytest.fixture(scope='function')

--- a/src/panoptes/utils/database/base.py
+++ b/src/panoptes/utils/database/base.py
@@ -172,6 +172,7 @@ class PanDB(object):
     def permanently_erase_database(cls,
                                    db_type,
                                    db_name,
+                                   storage_dir=None,
                                    really=False,
                                    dangerous=False,
                                    *args, **kwargs):
@@ -184,4 +185,4 @@ class PanDB(object):
             raise Exception('PanDB.permanently_erase_database called with invalid args!')
 
         # Load the correct DB module and do the deletion.
-        get_db_class(db_type).permanently_erase_database(db_name, *args, **kwargs)
+        get_db_class(db_type).permanently_erase_database(db_name, storage_dir=storage_dir, *args, **kwargs)

--- a/src/panoptes/utils/database/file.py
+++ b/src/panoptes/utils/database/file.py
@@ -14,13 +14,17 @@ from ..logging import logger
 class PanFileDB(AbstractPanDB):
     """Stores collections as files of JSON records."""
 
-    def __init__(self, db_name='panoptes', **kwargs):
-        """Flat file storage for json records
+    def __init__(self, db_name='panoptes', storage_dir='json_store', **kwargs):
+        """Flat file storage for json records.
 
         This will simply store each json record inside a file corresponding
         to the type. Each entry will be stored in a single line.
+
         Args:
             db_name (str, optional): Name of the database containing the collections.
+            storage_dir (str, optional): The name of the directory in $PANDIR where
+                the database files will be stored. Default is `json_store` for backwards
+                compatibility.
         """
 
         super().__init__(db_name=db_name, **kwargs)
@@ -28,8 +32,8 @@ class PanFileDB(AbstractPanDB):
         self.db_folder = db_name
 
         # Set up storage directory.
-        self._storage_dir = os.path.join(os.environ['PANDIR'], 'json_store', self.db_folder)
-        os.makedirs(self._storage_dir, exist_ok=True)
+        self.storage_dir = os.path.join(os.environ['PANDIR'], storage_dir, self.db_folder)
+        os.makedirs(self.storage_dir, exist_ok=True)
 
     def insert_current(self, collection, obj, store_permanently=True):
         obj_id = self._make_id()
@@ -98,14 +102,14 @@ class PanFileDB(AbstractPanDB):
             name = f'{collection}.json'
         else:
             name = f'current_{collection}.json'
-        return os.path.join(self._storage_dir, name)
+        return os.path.join(self.storage_dir, name)
 
     def _make_id(self):
         return str(uuid4())
 
     @classmethod
-    def permanently_erase_database(cls, db_name):
+    def permanently_erase_database(cls, storage_dir, db_name):
         # Clear out any .json files.
-        storage_dir = os.path.join(os.environ['PANDIR'], 'json_store', db_name)
+        storage_dir = os.path.join(os.environ['PANDIR'], storage_dir, db_name)
         for f in glob(os.path.join(storage_dir, '*.json')):
             os.remove(f)

--- a/src/panoptes/utils/database/file.py
+++ b/src/panoptes/utils/database/file.py
@@ -108,7 +108,7 @@ class PanFileDB(AbstractPanDB):
         return str(uuid4())
 
     @classmethod
-    def permanently_erase_database(cls, storage_dir, db_name):
+    def permanently_erase_database(cls, db_name, storage_dir='json_store'):
         # Clear out any .json files.
         storage_dir = os.path.join(os.environ['PANDIR'], storage_dir, db_name)
         for f in glob(os.path.join(storage_dir, '*.json')):

--- a/src/panoptes/utils/database/memory.py
+++ b/src/panoptes/utils/database/memory.py
@@ -88,7 +88,7 @@ class PanMemoryDB(AbstractPanDB):
             del self.current[entry_type]
 
     @classmethod
-    def permanently_erase_database(cls, db_name):
+    def permanently_erase_database(cls, *args, **kwargs):
         # For some reason we're not seeing all the references disappear
         # after tests. Perhaps there is some global variable pointing at
         # the db or one of its referrers, or perhaps a pytest fixture

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -74,5 +74,6 @@ def test_delete_file_db():
     with pytest.raises(ValueError):
         PanDB.permanently_erase_database('memory', 'do_not_delete_me', really='Nope', dangerous='Again, we hope not')
 
-    PanDB.permanently_erase_database('file', 'testing', 'panoptes_testing', really='Yes', dangerous='Totally')
+    PanDB.permanently_erase_database('file', 'panoptes_testing', storage_dir='testing', really='Yes',
+                                     dangerous='Totally')
     PanDB.permanently_erase_database('memory', 'panoptes_testing', dangerous='Totally', really='Yes')

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6,7 +6,7 @@ from panoptes.utils import error
 
 def test_bad_db():
     with pytest.raises(Exception):
-        PanDB('foobar')
+        PanDB('foobar', storage_dir='')
 
 
 def test_insert_and_no_permanent(db):
@@ -74,5 +74,5 @@ def test_delete_file_db():
     with pytest.raises(ValueError):
         PanDB.permanently_erase_database('memory', 'do_not_delete_me', really='Nope', dangerous='Again, we hope not')
 
-    PanDB.permanently_erase_database('file', 'panoptes_testing', really='Yes', dangerous='Totally')
+    PanDB.permanently_erase_database('file', 'testing', 'panoptes_testing', really='Yes', dangerous='Totally')
     PanDB.permanently_erase_database('memory', 'panoptes_testing', dangerous='Totally', really='Yes')


### PR DESCRIPTION
* Allow the file storage dir to be customized.
* Still assumes the directory is relative to `$PANDIR`.

Closes #87 
Required by https://github.com/panoptes/POCS/pull/957