### PR TITLE
Fix cloudbuild

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -8,6 +8,14 @@ substitutions:
   _TAG: latest
 
 steps:
+  # Fetch teh repo from github
+  - name: "gcr.io/cloud-builders/git"
+    id: "fetch-history"
+    args:
+      - "fetch"
+      - "--unshallow"
+    waitFor: ["build-builder"]
+
   # Set up multiarch support
   - name: "gcr.io/cloud-builders/docker"
     id: "setup-buildx"

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -48,6 +48,11 @@ steps:
       - "."
     waitFor: ["build-builder"]
 
+  - name: "gcr.io/cloud-builders/git"
+    id: "fetch-history"
+    args: ['fetch', '--unshallow']
+    waitFor: ["build-builder"]
+
   # Build
   - name: "gcr.io/cloud-builders/docker"
     id: "build-images"
@@ -62,4 +67,4 @@ steps:
       - "--tag=gcr.io/${PROJECT_ID}/panoptes-utils:${_TAG}"
       - "--cache-from=gcr.io/${PROJECT_ID}/panoptes-utils:${_TAG}"
       - "."
-    waitFor: ["build-base"]
+    waitFor: ["fetch-history"]

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -8,6 +8,12 @@ substitutions:
   _TAG: latest
 
 steps:
+  # Fetch teh repo from github
+  - name: "gcr.io/cloud-builders/git"
+    id: "fetch-history"
+    args: ['fetch', '--unshallow']
+    waitFor: ["build-builder"]
+
   # Set up multiarch support
   - name: "gcr.io/cloud-builders/docker"
     id: "setup-buildx"
@@ -48,10 +54,6 @@ steps:
       - "."
     waitFor: ["build-builder"]
 
-  - name: "gcr.io/cloud-builders/git"
-    id: "fetch-history"
-    args: ['fetch', '--unshallow']
-    waitFor: ["build-builder"]
 
   # Build
   - name: "gcr.io/cloud-builders/docker"

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -11,7 +11,9 @@ steps:
   # Fetch teh repo from github
   - name: "gcr.io/cloud-builders/git"
     id: "fetch-history"
-    args: ['fetch', '--unshallow']
+    args:
+      - "fetch"
+      - "--unshallow"
     waitFor: ["build-builder"]
 
   # Set up multiarch support

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -8,14 +8,6 @@ substitutions:
   _TAG: latest
 
 steps:
-  # Fetch teh repo from github
-  - name: "gcr.io/cloud-builders/git"
-    id: "fetch-history"
-    args:
-      - "fetch"
-      - "--unshallow"
-    waitFor: ["build-builder"]
-
   # Set up multiarch support
   - name: "gcr.io/cloud-builders/docker"
     id: "setup-buildx"


### PR DESCRIPTION
Replacing #233 as GCR doesn't seem to rebuild the context with new pushes to the cloudbuild.yaml file itself.