### PR TITLE
Add bit_depth argument to mask_saturated, no longer convert to float64 by default

### DIFF
--- a/src/panoptes/utils/images/__init__.py
+++ b/src/panoptes/utils/images/__init__.py
@@ -261,9 +261,11 @@ def mask_saturated(data, saturation_level=None, threshold=0.9, bit_depth=None, d
                                              f"got {bit_depth!r}")
 
             bit_depth = int(bit_depth)
+            logger.trace(f"Using bit depth {bit_depth!r}")
             saturation_level = threshold * (2**bit_depth - 1)
         else:
             # No bit depth specified, try to guess.
+            logger.trace(f"Inferring bit_depth from data type, {data.dtype!r}")
             try:
             # Try to use np.iinfo to compute machine limits. Will work for integer types.
                 saturation_level = threshold * np.iinfo(data.dtype).max
@@ -272,7 +274,7 @@ def mask_saturated(data, saturation_level=None, threshold=0.9, bit_depth=None, d
                 raise error.IllegalValue("Neither saturation_level or bit_depth given, and data " +
                                          "is not an integer type. Cannot determine correct " +
                                          "saturation level.")
-
+    logger.debug(f"Masking image using saturation level {saturation_level!r}")
     # Convert data to masked array of requested dtype, mask values above saturation level.
     return np.ma.array(data, mask=(data > saturation_level), dtype=dtype)
 

--- a/src/panoptes/utils/images/__init__.py
+++ b/src/panoptes/utils/images/__init__.py
@@ -13,6 +13,7 @@ from matplotlib.figure import Figure
 from astropy.wcs import WCS
 from astropy.nddata import Cutout2D
 from astropy.visualization import (PercentileInterval, LogStretch, ImageNormalize)
+from astropy import units as u
 
 from .. import error
 from ..logging import logger
@@ -221,33 +222,56 @@ def _make_pretty_from_cr2(fname, title=None, **kwargs):
     return fname.replace('cr2', 'jpg')
 
 
-def mask_saturated(data, saturation_level=None, threshold=0.9, dtype=np.float64):
-    """Convert data to masked array of requested dtype with saturated values masked.
+def mask_saturated(data, saturation_level=None, threshold=0.9, bit_depth=None):
+    """Convert data to a masked array with saturated values masked.
 
     Args:
         data (array_like): The numpy data array.
-        saturation_level (float, optional): The saturation level. If None,
-            the level will be set to the threshold times the max value for the dtype.
-        threshold (float, optional): The percentage of the max value to use.
-        dtype (numpy.dtype, optional): The requested dtype for the new array.
+        saturation_level (scalar, optional): The saturation level. If not given then the
+            saturation level will be set to threshold times the maximum pixel value.
+        threshold (float, optional): The fraction of the maximum pixel value to use as
+            the saturation level, default 0.9.
+        bit_depth (astropy.units.Quantity or int, optional): The effective bit depth of the
+            data. If given the maximum pixel value will be assumed to be 2**bit_depth,
+            otherwise an attempt will be made to infer the maximum pixel value from the
+            data type of the data. If data is not an integer type the maximum pixel value
+            cannot be inferred and an IllegalValue exception will be raised.
 
     Returns:
         numpy.ma.array: The masked numpy array.
+
+    Raises:
+        error.IllegalValue: Raised if bit_depth is an astropy.units.Quantity object but the
+            units are not compatible with either bits or bits/pixel.
+        error.IllegalValue: Raised if neither saturation level or bit_depth are given, and data
+            has a non integer data type.
     """
     if not saturation_level:
-        try:
-            # If data is an integer type use iinfo to compute machine limits.
-            dtype_info = np.iinfo(data.dtype)
-        except ValueError:
-            # Not an integer type. Assume for now we have 16 bit data.
-            saturation_level = threshold * (2 ** 16 - 1)
-        else:
-            # Data is an integer type, set saturation level at specified fraction of
-            # max value for the type.
-            saturation_level = threshold * dtype_info.max
+        if bit_depth is not None:
+            try:
+                with suppress(AttributeError):
+                    bit_depth = bit_depth.to_value(unit=u.bit)
+            except u.UnitConversionError:
+                try:
+                    bit_depth = bit_depth.to_value(unit=u.bit / u.pixel)
+                except u.UnitConversionError:
+                    raise error.IllegalValue("bit_depth must have units of bits or bits/pixel, " +
+                                             f"got {bit_depth!r}")
 
-    # Convert data to masked array of requested dtype, mask values above saturation level.
-    return np.ma.array(data, mask=(data > saturation_level), dtype=dtype)
+            bit_depth = int(bit_depth)
+            saturation_level = threshold * (2**bit_depth - 1)
+        else:
+            # No bit depth specified, try to guess.
+            try:
+            # Try to use np.iinfo to compute machine limits. Will work for integer types.
+                saturation_level = threshold * dtype_info = np.iinfo(data.dtype).max
+            except ValueError:
+                # ValueError from np.iinfo means not an integer type.
+                raise error.IllegalValue("Neither saturation_level or bit_depth given, & data " +
+                                         "is not an integer type. Cannot determine correct " +
+                                         "saturation level.")
+
+    return np.ma.array(data, mask=(data > saturation_level))
 
 
 def make_timelapse(

--- a/src/panoptes/utils/images/__init__.py
+++ b/src/panoptes/utils/images/__init__.py
@@ -273,6 +273,7 @@ def mask_saturated(data, saturation_level=None, threshold=0.9, bit_depth=None, d
                                          "is not an integer type. Cannot determine correct " +
                                          "saturation level.")
 
+    # Convert data to masked array of requested dtype, mask values above saturation level.
     return np.ma.array(data, mask=(data > saturation_level), dtype=dtype)
 
 

--- a/src/panoptes/utils/images/__init__.py
+++ b/src/panoptes/utils/images/__init__.py
@@ -269,7 +269,7 @@ def mask_saturated(data, saturation_level=None, threshold=0.9, bit_depth=None, d
                 saturation_level = threshold * np.iinfo(data.dtype).max
             except ValueError:
                 # ValueError from np.iinfo means not an integer type.
-                raise error.IllegalValue("Neither saturation_level or bit_depth given, & data " +
+                raise error.IllegalValue("Neither saturation_level or bit_depth given, and data " +
                                          "is not an integer type. Cannot determine correct " +
                                          "saturation level.")
 

--- a/src/panoptes/utils/images/__init__.py
+++ b/src/panoptes/utils/images/__init__.py
@@ -222,7 +222,7 @@ def _make_pretty_from_cr2(fname, title=None, **kwargs):
     return fname.replace('cr2', 'jpg')
 
 
-def mask_saturated(data, saturation_level=None, threshold=0.9, bit_depth=None):
+def mask_saturated(data, saturation_level=None, threshold=0.9, bit_depth=None, dtype=None):
     """Convert data to a masked array with saturated values masked.
 
     Args:
@@ -236,6 +236,8 @@ def mask_saturated(data, saturation_level=None, threshold=0.9, bit_depth=None):
             otherwise an attempt will be made to infer the maximum pixel value from the
             data type of the data. If data is not an integer type the maximum pixel value
             cannot be inferred and an IllegalValue exception will be raised.
+        dtype (numpy.dtype, optional): The requested dtype for the masked array. If not given
+            the dtype of the masked array will be same as data.
 
     Returns:
         numpy.ma.array: The masked numpy array.
@@ -271,7 +273,7 @@ def mask_saturated(data, saturation_level=None, threshold=0.9, bit_depth=None):
                                          "is not an integer type. Cannot determine correct " +
                                          "saturation level.")
 
-    return np.ma.array(data, mask=(data > saturation_level))
+    return np.ma.array(data, mask=(data > saturation_level), dtype=dtype)
 
 
 def make_timelapse(

--- a/src/panoptes/utils/images/__init__.py
+++ b/src/panoptes/utils/images/__init__.py
@@ -266,7 +266,7 @@ def mask_saturated(data, saturation_level=None, threshold=0.9, bit_depth=None, d
             # No bit depth specified, try to guess.
             try:
             # Try to use np.iinfo to compute machine limits. Will work for integer types.
-                saturation_level = threshold * dtype_info = np.iinfo(data.dtype).max
+                saturation_level = threshold * np.iinfo(data.dtype).max
             except ValueError:
                 # ValueError from np.iinfo means not an integer type.
                 raise error.IllegalValue("Neither saturation_level or bit_depth given, & data " +

--- a/src/panoptes/utils/images/focus.py
+++ b/src/panoptes/utils/images/focus.py
@@ -1,3 +1,4 @@
+import numpy as np
 
 
 def focus_metric(data, merit_function='vollath_F4', **kwargs):

--- a/src/panoptes/utils/images/focus.py
+++ b/src/panoptes/utils/images/focus.py
@@ -42,6 +42,10 @@ def vollath_F4(data, axis=None):
     Returns:
         float64: Calculated F4 value for y, x axis or both
     """
+    # This calculation is prone to integer overflow if data is an integer type
+    # so convert to float64 before doing anything else.
+    data = data.astype(np.float64)
+
     def _vollath_F4_y():
         A1 = (data[1:] * data[:-1]).mean()
         A2 = (data[2:] * data[:-2]).mean()

--- a/tests/images/test_focus_utils.py
+++ b/tests/images/test_focus_utils.py
@@ -1,6 +1,8 @@
 import os
 import pytest
 
+import numpy as np
+
 from astropy.io import fits
 
 from panoptes.utils.images import mask_saturated
@@ -9,7 +11,7 @@ from panoptes.utils.images import focus as focus_utils
 
 def test_vollath_f4(data_dir):
     data = fits.getdata(os.path.join(data_dir, 'unsolved.fits'))
-    data = mask_saturated(data)
+    data = mask_saturated(data, dtype=np.float64)
     assert focus_utils.vollath_F4(data) == pytest.approx(14667.207897717599)
     assert focus_utils.vollath_F4(data, axis='Y') == pytest.approx(14380.343807477504)
     assert focus_utils.vollath_F4(data, axis='X') == pytest.approx(14954.071987957694)
@@ -19,7 +21,7 @@ def test_vollath_f4(data_dir):
 
 def test_focus_metric_default(data_dir):
     data = fits.getdata(os.path.join(data_dir, 'unsolved.fits'))
-    data = mask_saturated(data)
+    data = mask_saturated(data, dtype=np.float64)
     assert focus_utils.focus_metric(data) == pytest.approx(14667.207897717599)
     assert focus_utils.focus_metric(data, axis='Y') == pytest.approx(14380.343807477504)
     assert focus_utils.focus_metric(data, axis='X') == pytest.approx(14954.071987957694)
@@ -29,7 +31,7 @@ def test_focus_metric_default(data_dir):
 
 def test_focus_metric_vollath(data_dir):
     data = fits.getdata(os.path.join(data_dir, 'unsolved.fits'))
-    data = mask_saturated(data)
+    data = mask_saturated(data, dtype=np.float64)
     assert focus_utils.focus_metric(
         data, merit_function='vollath_F4') == pytest.approx(14667.207897717599)
     assert focus_utils.focus_metric(
@@ -46,6 +48,6 @@ def test_focus_metric_vollath(data_dir):
 
 def test_focus_metric_bad_string(data_dir):
     data = fits.getdata(os.path.join(data_dir, 'unsolved.fits'))
-    data = mask_saturated(data)
+    data = mask_saturated(data, dtype=np.float64)
     with pytest.raises(KeyError):
         focus_utils.focus_metric(data, merit_function='NOTAMERITFUNCTION')

--- a/tests/images/test_focus_utils.py
+++ b/tests/images/test_focus_utils.py
@@ -1,8 +1,6 @@
 import os
 import pytest
 
-import numpy as np
-
 from astropy.io import fits
 
 from panoptes.utils.images import mask_saturated

--- a/tests/images/test_focus_utils.py
+++ b/tests/images/test_focus_utils.py
@@ -11,7 +11,7 @@ from panoptes.utils.images import focus as focus_utils
 
 def test_vollath_f4(data_dir):
     data = fits.getdata(os.path.join(data_dir, 'unsolved.fits'))
-    data = mask_saturated(data, dtype=np.float64)
+    data = mask_saturated(data)
     assert focus_utils.vollath_F4(data) == pytest.approx(14667.207897717599)
     assert focus_utils.vollath_F4(data, axis='Y') == pytest.approx(14380.343807477504)
     assert focus_utils.vollath_F4(data, axis='X') == pytest.approx(14954.071987957694)
@@ -21,7 +21,7 @@ def test_vollath_f4(data_dir):
 
 def test_focus_metric_default(data_dir):
     data = fits.getdata(os.path.join(data_dir, 'unsolved.fits'))
-    data = mask_saturated(data, dtype=np.float64)
+    data = mask_saturated(data)
     assert focus_utils.focus_metric(data) == pytest.approx(14667.207897717599)
     assert focus_utils.focus_metric(data, axis='Y') == pytest.approx(14380.343807477504)
     assert focus_utils.focus_metric(data, axis='X') == pytest.approx(14954.071987957694)
@@ -31,7 +31,7 @@ def test_focus_metric_default(data_dir):
 
 def test_focus_metric_vollath(data_dir):
     data = fits.getdata(os.path.join(data_dir, 'unsolved.fits'))
-    data = mask_saturated(data, dtype=np.float64)
+    data = mask_saturated(data)
     assert focus_utils.focus_metric(
         data, merit_function='vollath_F4') == pytest.approx(14667.207897717599)
     assert focus_utils.focus_metric(
@@ -48,6 +48,6 @@ def test_focus_metric_vollath(data_dir):
 
 def test_focus_metric_bad_string(data_dir):
     data = fits.getdata(os.path.join(data_dir, 'unsolved.fits'))
-    data = mask_saturated(data, dtype=np.float64)
+    data = mask_saturated(data)
     with pytest.raises(KeyError):
         focus_utils.focus_metric(data, merit_function='NOTAMERITFUNCTION')


### PR DESCRIPTION
`panoptes.utils.images.mask_saturated()` function currently works with either a directly specified `saturation_level` (an optional argument), or by attempting to infer the maximum pixel value and multiplying that by a `threshold` (another optional argument, which defaults to 0.9). There are several problems with the way it infers the maximum pixel value:

1. The use of data type to infer maximum pixel value will give the wrong result if the actual bit depth of the data is lower than the data type would imply (e.g. images from 12 or 14 bits/pixel cameras in `numpy.uint16` arrays).
1. If the data type is not an integer type it is silently assumed that the maximum pixel value is `2**16 - 1`, but in general this will not be true.

This PR addresses these problem by:

1. Adding an optional `bit_depth` argument that can be used to directly specify bit depth for cases where it differs from the bits/pixel of the data type. The maximum pixel value is then taken to be `2**bit_depth - 1`.
1. Raising `error.IllegalValue` if neither `saturation_level` nor `bit_depth` are given, & the data does not have an integer data type. It is unsafe to guess the maximum pixel value in this situation, so `mask_saturation()` will not try.

Currently `mask_saturated` will convert the data to `numpy.float64` by default when creating the masked array. This behaviour can be overriden by specifying a `dtype` for the masked array using the optional `dtype` argument. This PR changes the default behaviour to keep the `dtype` of the input `data` instead, while still allowing a different `dtype` to be specified.
