### PR TITLE
Move back to python 3.7

### DIFF
--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.8 ]
+        python-version: [ 3.7 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.8 ]
+        python-version: [ 3.7 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -130,7 +130,7 @@ Added
   * If a semantically tagged branch is pushed to GH, a release will automatically be generated and a package will be built and sent to PyPi. (#237)
 
 Changed
--------
+^^^^^^^
 
 * Changelog fixes. (#237)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog
 Changed
 ^^^^^^^
 
+* Reverting back to ``python=3.7`` for compatibility w/ GCP notebooks. (@wtgee #255)
+* Freezing ``astropy<=4.0.1`` while we wait for ``astroplan`` to get pushed. (@wtgee #255)
 * Changed the horizon module to use numpy interpolation so we don't need to explicitly install scipy. (@wtgee #248)
 * ``altaz_to_radec`` accepts astropy quantities. (@wtgee #250)
 * Downloaded helper script doesn't have ``python3`` hardcoded. (@wtgee #250)
@@ -104,7 +106,7 @@ This release is mostly cleanup and testing of our autobuild features.
 Changed
 ^^^^^^^
 
-* Splitting the `panoptes-base` files into separate folder. (#238)
+* Splitting the ``panoptes-base`` files into separate folder. (#238)
 * Consolidate the GitHub Actions for building and publishing a release package. (#239)
 
 Fixed

--- a/resources/environment.yaml
+++ b/resources/environment.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.7
   - astroplan
-  - astropy
+  - astropy<=4.0.1
   - click
   - gevent
   - loguru

--- a/resources/environment.yaml
+++ b/resources/environment.yaml
@@ -2,7 +2,7 @@ name: base
 channels:
   - https://conda.anaconda.org/conda-forge
 dependencies:
-  - python=3.8
+  - python=3.7
   - astroplan
   - astropy
   - click

--- a/resources/environment.yaml
+++ b/resources/environment.yaml
@@ -2,7 +2,7 @@ name: base
 channels:
   - https://conda.anaconda.org/conda-forge
 dependencies:
-  - python=3.7
+  - python=3.8
   - astroplan
   - astropy
   - click

--- a/scripts/download-data.py
+++ b/scripts/download-data.py
@@ -123,7 +123,7 @@ class Downloader(object):
             return True
         url = f"http://data.astrometry.net/{fn}"
         try:
-            logger.debug(f'Downloading {url=}')
+            logger.debug(f'Downloading {url}')
             df = data.download_file(url)
         except Exception as e:
             if not self.keep_going:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3 :: Only
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Scientific/Engineering :: Physics

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ install_requires =
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-python_requires = >=3.8
+python_requires = >=3.7
 
 [options.packages.find]
 where = src

--- a/src/panoptes/utils/config/cli.py
+++ b/src/panoptes/utils/config/cli.py
@@ -88,7 +88,7 @@ def stop(context):
     """Stops the config server by setting a flag in the server itself."""
     host = context.obj.get('host')
     port = context.obj.get('port')
-    logger.info('Shutting down config server on {host}:{port}')
+    logger.info(f'Shutting down config server on {host}:{port}')
     set_config('config_server.running', False, host=host, port=port)
 
 

--- a/src/panoptes/utils/config/cli.py
+++ b/src/panoptes/utils/config/cli.py
@@ -66,7 +66,7 @@ def run(context, config_file=None, save_local=True, load_local=False, heartbeat=
     try:
         print(f'Starting config server. Ctrl-c to stop')
         server_process.start()
-        print(f'Config server started on {server_process.pid=}. '
+        print(f'Config server started on  server_process.pid={server_process.pid!r}. '
               f'Set "config_server.running=False" or Ctrl-c to stop')
 
         # Loop until config told to stop.
@@ -111,14 +111,14 @@ def config_getter(context, key, parse=True, default=None):
         key = key[0]
     except IndexError:
         key = None
-    logger.debug(f'Getting config {key=}')
+    logger.debug(f'Getting config  key={key!r}')
     try:
         config_entry = get_config(key=key, host=host, port=port, parse=parse, default=default)
     except Exception as e:
         logger.error(f'Error while trying to get config: {e!r}')
         click.secho(f'Error while trying to get config: {e!r}', fg='red')
     else:
-        logger.debug(f'Config server response: {config_entry=}')
+        logger.debug(f'Config server response:  config_entry={config_entry!r}')
         click.echo(config_entry)
 
 
@@ -134,7 +134,7 @@ def config_setter(context, key, new_value, parse=True):
     host = context.obj.get('host')
     port = context.obj.get('port')
 
-    logger.debug(f'Setting config {key=} {new_value=} on {host}:{port}')
+    logger.debug(f'Setting config key={key!r}  new_value={new_value!r} on {host}:{port}')
     config_entry = set_config(key, new_value, host=host, port=port, parse=parse)
     click.echo(config_entry)
 

--- a/src/panoptes/utils/config/client.py
+++ b/src/panoptes/utils/config/client.py
@@ -98,28 +98,28 @@ def get_config(key=None,
     config_entry = default
 
     try:
-        logger.log(log_level, f'Calling get_config on {url=} with {key=}')
+        logger.log(log_level, f'Calling get_config on url={url!r} with  key={key!r}')
         response = requests.post(url, json={'key': key, 'verbose': verbose})
         if not response.ok:  # pragma: no cover
-            raise InvalidConfig(f'Config server returned invalid JSON: {response.content=}')
+            raise InvalidConfig(f'Config server returned invalid JSON:  response.content={response.content!r}')
     except Exception as e:
         logger.warning(f'Problem with get_config: {e!r}')
     else:
         response_text = response.text.strip()
-        logger.log(log_level, f'Decoded {response_text=}')
+        logger.log(log_level, f'Decoded  response_text={response_text!r}')
         if response_text != 'null':
-            logger.log(log_level, f'Received config {key=} {response_text=}')
+            logger.log(log_level, f'Received config key={key!r}  response_text={response_text!r}')
             if parse:
-                logger.log(log_level, f'Parsing config results: {response_text=}')
+                logger.log(log_level, f'Parsing config results:  response_text={response_text!r}')
                 config_entry = from_json(response_text)
             else:
                 config_entry = response_text
 
     if config_entry is None:
-        logger.log(log_level, f'No config entry found, returning {default=}')
+        logger.log(log_level, f'No config entry found, returning  default={default!r}')
         config_entry = default
 
-    logger.log(log_level, f'Config {key=}: {config_entry=}')
+    logger.log(log_level, f'Config key={key!r}:  config_entry={config_entry!r}')
     return config_entry
 
 
@@ -172,7 +172,7 @@ def set_config(key, new_value, host=None, port=None, parse=True):
     config_entry = None
     try:
         # We use our own serializer so pass as `data` instead of `json`.
-        logger.info(f'Calling set_config on {url=}')
+        logger.info(f'Calling set_config on  url={url!r}')
         response = requests.post(url,
                                  data=json_str,
                                  headers={'Content-Type': 'application/json'}

--- a/src/panoptes/utils/config/helpers.py
+++ b/src/panoptes/utils/config/helpers.py
@@ -61,13 +61,13 @@ def load_config(config_files=None, parse=True, load_local=True):
     config = dict()
 
     config_files = listify(config_files)
-    logger.debug(f'Loading config files: {config_files=}')
+    logger.debug(f'Loading config files:  config_files={config_files!r}')
     for config_file in config_files:
         try:
-            logger.debug(f'Adding {config_file=} to config dict')
+            logger.debug(f'Adding  config_file={config_file!r} to config dict')
             _add_to_conf(config, config_file, parse=parse)
         except Exception as e:  # pragma: no cover
-            logger.warning(f"Problem with {config_file=}, skipping. {e!r}")
+            logger.warning(f"Problem with  config_file={config_file!r}, skipping. {e!r}")
 
         # Load local version of config
         if load_local:
@@ -76,14 +76,14 @@ def load_config(config_files=None, parse=True, load_local=True):
                 try:
                     _add_to_conf(config, local_version, parse=parse)
                 except Exception as e:  # pragma: no cover
-                    logger.warning(f"Problem with {local_version=}, skipping: {e!r}")
+                    logger.warning(f"Problem with  local_version={local_version!r}, skipping: {e!r}")
 
     # parse_config_directories currently only corrects directory names.
     if parse:
-        logger.trace(f'Parsing {config=}')
+        logger.trace(f'Parsing  config={config!r}')
         with suppress(KeyError):
             config['directories'] = parse_config_directories(config['directories'])
-            logger.trace(f'Config directories parsed: {config=}')
+            logger.trace(f'Config directories parsed:  config={config!r}')
 
     return config
 
@@ -167,17 +167,18 @@ def parse_config_directories(directories, must_exist=False):
     # Try to get the base directory first.
     base_dir = directories.get('base', os.environ['PANDIR'])
     if os.path.isdir(base_dir):
-        logger.trace(f'Using {base_dir=} for setting config directories')
+        logger.trace(f'Using  base_dir={base_dir!r} for setting config directories')
 
         # Add the base directory to any relative dir.
         for dir_name, rel_dir in directories.items():
             # Only want relative directories.
             if rel_dir.startswith('/') is False:
                 abs_dir = os.path.join(base_dir, rel_dir)
-                logger.trace(f'{base_dir=} {rel_dir=} {abs_dir=} {must_exist=}')
+                logger.trace(
+                    f'base_dir={base_dir!r} rel_dir={rel_dir!r} abs_dir={abs_dir!r}  must_exist={must_exist!r}')
 
                 if must_exist and not os.path.exists(abs_dir):
-                    logger.warning(f'{must_exist=} but {abs_dir=} does not exist, skipping')
+                    logger.warning(f'must_exist={must_exist!r} but  abs_dir={abs_dir!r} does not exist, skipping')
                 else:
                     logger.trace(f'Setting {dir_name} to {abs_dir}')
                     directories[dir_name] = abs_dir

--- a/src/panoptes/utils/config/server.py
+++ b/src/panoptes/utils/config/server.py
@@ -72,7 +72,7 @@ def config_server(config_file,
         multiprocessing.Process: The process running the config server.
     """
     config_file = config_file or os.environ['PANOPTES_CONFIG_FILE']
-    logger.info(f'Starting panoptes-config-server with {config_file=}')
+    logger.info(f'Starting panoptes-config-server with  config_file={config_file!r}')
     config = load_config(config_files=config_file, load_local=load_local)
     logger.success(f'Config server Loaded {len(config)} top-level items')
 
@@ -108,7 +108,7 @@ def config_server(config_file,
     host = host or os.getenv('PANOPTES_CONFIG_HOST', 'localhost')
     port = port or os.getenv('PANOPTES_CONFIG_PORT', 6563)
     cmd_kwargs = dict(host=host, port=port)
-    logger.debug(f'Setting up config server process with {cmd_kwargs=}')
+    logger.debug(f'Setting up config server process with  cmd_kwargs={cmd_kwargs!r}')
     server_process = Process(target=start_server,
                              daemon=True,
                              kwargs=cmd_kwargs)
@@ -186,12 +186,12 @@ def get_config_entry():
     log_level = 'DEBUG' if verbose else 'TRACE'
 
     # If requesting specific key
-    logger.log(log_level, f'Received {params=}')
+    logger.log(log_level, f'Received  params={params!r}')
 
     if request.is_json:
         try:
             key = params['key']
-            logger.log(log_level, f'Request contains {key=}')
+            logger.log(log_level, f'Request contains  key={key!r}')
         except KeyError:
             return jsonify({
                 'success': False,
@@ -204,7 +204,7 @@ def get_config_entry():
             show_config = app.config['POCS']
         else:
             try:
-                logger.log(log_level, f'Looking for {key=} in config')
+                logger.log(log_level, f'Looking for  key={key!r} in config')
                 show_config = app.config['POCS_cut'].get(key, None)
             except Exception as e:
                 logger.error(f'Error while getting config item: {e!r}')
@@ -214,7 +214,7 @@ def get_config_entry():
         logger.log(log_level, 'No valid key given, returning entire config')
         show_config = app.config['POCS']
 
-    logger.log(log_level, f'Returning {show_config=}')
+    logger.log(log_level, f'Returning  show_config={show_config!r}')
     logger.log(log_level, f'Returning {show_config!r}')
     return jsonify(show_config)
 
@@ -277,7 +277,7 @@ def set_config_entry():
 
     # Config has been modified so save to file.
     save_local = app.config['save_local']
-    logger.info(f'Setting config {save_local=}')
+    logger.info(f'Setting config  save_local={save_local!r}')
     if save_local and app.config['config_file'] is not None:
         save_config(app.config['config_file'], app.config['POCS_cut'].copy())
 

--- a/src/panoptes/utils/images/__init__.py
+++ b/src/panoptes/utils/images/__init__.py
@@ -213,7 +213,7 @@ def _make_pretty_from_cr2(fname, title=None, **kwargs):
 
     try:
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        logger.debug(f'Pretty CR2 {output=}')
+        logger.debug(f'Pretty CR2  output={output!r}')
     except subprocess.CalledProcessError as e:
         raise error.InvalidCommand(f"Error executing {script_name}: {e.output!r}\nCommand: {cmd}")
 


### PR DESCRIPTION
Some compatibility issues down the chain, so we want to keep this at 3.7 for now. Mostly this means removing the `{=}` construct.

Also locking astropy version until updated astroplan available (see https://github.com/astropy/astroplan/issues/485).