### PR TITLE
Docker build updates - zsh fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Fixed
 ^^^^^
 
 * Fixed the ``oh-my-zsh`` path for Docker install. (@wtgee #256)
+* Return testing output from docker container, passint exit status. (@wtgee #256)
 
 Removed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Changelog
 0.2.29dev
 ---------
 
+Added
+^^^^^
+
+* Config Server:
+
+  * Option to start a heartbeat or not. (@wtgee #248)
+
 Changed
 ^^^^^^^
 
@@ -15,28 +22,31 @@ Changed
 * Downloaded helper script doesn't have ``python3`` hardcoded. (@wtgee #250)
 * Docker Tools (@wtgee #248):
 
-  * Remove ``source-extractor`` from ``panoptes-utils`` and move to ``panoptes-pipeline``. (@wtgee #252)
-  * Remove ``imagemagick`` from ``panoptes-utils``. This is used for adding titles to JPGs. (@wtgee #252)
-  * Don't install a separate conda environment, just use the base to help reduce image size, complexity. (@wtgee #252)
-  * Cleanup unused dependencies. (@wtgee @252)
   * Conda environment built from ``resources/environment.yaml``. (@wtgee #252)
   * Adds a "developer" dockerfile and compose file to install things for developers. (@wtgee #248)
   * Docker CMD will run ipython. (@wtgee #248)
   * docker-compose file will start a jupyter-lab instance. (@wtgee #248)
 
-* Config Server:
+Fixed
+^^^^^
 
-  * Option to start a heartbeat or not. (@wtgee #248)
-
-* Testing:
-
-  * Adios travis! (@wtgee #252)
+* Fixed the ``oh-my-zsh`` path for Docker install. (@wtgee #256)
 
 Removed
 ^^^^^^^
 
 * The ``stars`` module, which has been moved to ``panoptes-pipeline``. (@wtgee #251)
 * The ``metadata`` module, which has been moved to ``panoptes-pipeline``. (@wtgee #252)
+* Docker Tools (@wtgee #248):
+
+  * Remove ``source-extractor`` from ``panoptes-utils`` and move to ``panoptes-pipeline``. (@wtgee #252)
+  * Remove ``imagemagick`` from ``panoptes-utils``. This is used for adding titles to JPGs. (@wtgee #252)
+  * Don't install a separate conda environment, just use the base to help reduce image size, complexity. (@wtgee #252)
+  * Cleanup unused dependencies. (@wtgee @252)
+
+* Testing:
+
+  * Adios travis! (@wtgee #252)
 
 
 0.2.28 - 2020-09-15

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -12,6 +12,7 @@ ARG userid=1000
 ARG pan_dir=/var/panoptes
 ARG pocs_dir="${pan_dir}/POCS"
 ARG astrometry_dir="/astrometry/data"
+ARG zsh_url="https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh"
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
@@ -38,7 +39,7 @@ RUN apt-get update && \
     # All our shells are belong to Oh My ZSH w/ Spaceship prompt. :)
     mkdir -p "${ZSH_CUSTOM}" && \
     chmod -R 755 "${ZSH_CUSTOM}" && \
-    sh -c "$(wget https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O -)" && \
+    sh -c "$(wget ${zsh_url} -O -)" && \
     git clone --single-branch --quiet https://github.com/denysdovhan/spaceship-prompt.git "${ZSH_CUSTOM}/themes/spaceship-prompt" && \
     ln -s "${ZSH_CUSTOM}/themes/spaceship-prompt/spaceship.zsh-theme" "${ZSH_CUSTOM}/themes/spaceship.zsh-theme" && \
     git clone --single-branch --quiet https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM}/plugins/zsh-autosuggestions && \

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -40,8 +40,10 @@ RUN apt-get update && \
     mkdir -p "${ZSH_CUSTOM}" && \
     chmod -R 755 "${ZSH_CUSTOM}" && \
     sh -c "$(wget ${zsh_url} -O -)" && \
+    # ZSH theme.
     git clone --single-branch --quiet https://github.com/denysdovhan/spaceship-prompt.git "${ZSH_CUSTOM}/themes/spaceship-prompt" && \
     ln -s "${ZSH_CUSTOM}/themes/spaceship-prompt/spaceship.zsh-theme" "${ZSH_CUSTOM}/themes/spaceship.zsh-theme" && \
+    # ZSH auto-suggestion plugin.
     git clone --single-branch --quiet https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM}/plugins/zsh-autosuggestions && \
     # Copy zshrc for root user.
     cat "/tmp/zshrc" >> /root/.zshrc && \
@@ -93,7 +95,7 @@ RUN mkdir -p "${PANDIR}/scripts/" && \
     "${PANDIR}/conda/bin/python" "${PANDIR}/scripts/download-data.py" \
         --wide-field --narrow-field \
         --folder "${astrometry_dir}" \
-        --verbose && \
+        --verbose || exit 0 && \
     # Cleanup conda.
     "${PANDIR}/conda/bin/conda" clean -tipy
 

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
 timeout: 18000s  # 5 hours
 
 substitutions:
-  _TAG: latest
+  _TAG: develop
   _PLATFORMS: linux/amd64,linux/arm64
   _BASE_IMAGE: panoptes-base
   _IMAGE_NAME: panoptes-utils

--- a/scripts/testing/test-software.sh
+++ b/scripts/testing/test-software.sh
@@ -26,6 +26,3 @@ docker run --rm -i \
   -v "${PANLOG}":/var/panoptes/logs \
   panoptes-utils:develop \
   "/var/panoptes/panoptes-utils/scripts/testing/run-tests.sh"
-
-echo "test output dir ${PANLOG}:"
-ls "${PANLOG}/panoptes-testing.log"


### PR DESCRIPTION
* Fix zsh install path. The `oh-my-zsh` repo has moved into a new top-level project so the url has changed. Make it an `ARG` while we're at it.
* Fix test output return, closes #247 
* Default to `develop` tag for cloudbuild images.