### PR TITLE
Improved log message for CountdownTimer sleep

### DIFF
--- a/src/panoptes/utils/time.py
+++ b/src/panoptes/utils/time.py
@@ -163,11 +163,12 @@ class CountdownTimer(object):
         self.target_time = time.monotonic() + self.duration
         logger.debug(f'Restarting {self}')
 
-    def sleep(self, max_sleep=None):
+    def sleep(self, max_sleep=None, log_level='TRACE'):
         """Sleep until the timer expires, or for max_sleep, whichever is sooner.
 
         Args:
-            max_sleep: Number of seconds to wait for, or None.
+            max_sleep (int or None): Number of seconds to wait for, or None.
+            log_level (str): Log level for sleeping message, default TRACE.
         Returns:
             True if slept for less than time_left(), False otherwise.
         """
@@ -179,10 +180,9 @@ class CountdownTimer(object):
 
         # Sleep only for max time if requested.
         if max_sleep and max_sleep < remaining:
-            assert max_sleep > 0
-            sleep_time = max_sleep
+            sleep_time = min(max_sleep, 0)
 
-        logger.debug(f'Sleeping for {sleep_time:.02f} seconds')
+        logger.log(log_level.upper(), f'Sleeping for {sleep_time:.02f} seconds')
         time.sleep(sleep_time)
 
         return sleep_time < remaining
@@ -259,10 +259,13 @@ def wait_for_events(events,
         elapsed_secs = round((current_time() - start_time).to_value('second'), 2)
 
         if event_timer.expired():
-            raise error.Timeout(f"Timeout waiting for {len(events)} events after {elapsed_secs} seconds")
+            raise error.Timeout(
+                f"Timeout waiting for {len(events)} events after {elapsed_secs} seconds")
 
         if callable(callback) and callback() is False:
-            logger.warning(f"Waiting for {len(events)} events has been interrupted after {elapsed_secs} seconds")
+            logger.warning(
+                f"Waiting for {len(events)} events has been interrupted after {elapsed_secs} "
+                f"seconds")
             break
 
         # Sleep for a little bit.

--- a/src/panoptes/utils/time.py
+++ b/src/panoptes/utils/time.py
@@ -180,7 +180,7 @@ class CountdownTimer(object):
 
         # Sleep only for max time if requested.
         if max_sleep and max_sleep < remaining:
-            sleep_time = min(max_sleep, 0)
+            sleep_time = max(max_sleep, 0)
 
         logger.log(log_level.upper(), f'Sleeping for {sleep_time:.02f} seconds')
         time.sleep(sleep_time)

--- a/src/panoptes/utils/time.py
+++ b/src/panoptes/utils/time.py
@@ -163,12 +163,12 @@ class CountdownTimer(object):
         self.target_time = time.monotonic() + self.duration
         logger.debug(f'Restarting {self}')
 
-    def sleep(self, max_sleep=None, log_level='TRACE'):
+    def sleep(self, max_sleep=None, log_level='DEBUG'):
         """Sleep until the timer expires, or for max_sleep, whichever is sooner.
 
         Args:
             max_sleep (int or None): Number of seconds to wait for, or None.
-            log_level (str): Log level for sleeping message, default TRACE.
+            log_level (str): Log level for sleeping message, default DEBUG.
         Returns:
             True if slept for less than time_left(), False otherwise.
         """

--- a/src/panoptes/utils/time.py
+++ b/src/panoptes/utils/time.py
@@ -179,7 +179,7 @@ class CountdownTimer(object):
         sleep_time = remaining
 
         # Sleep only for max time if requested.
-        if max_sleep and max_sleep < remaining:
+        if max_sleep and max_sleep < sleep_time:
             sleep_time = max(max_sleep, 0)
 
         logger.log(log_level.upper(), f'Sleeping for {sleep_time:.02f} seconds')

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -93,7 +93,7 @@ def test_countdown_timer_sleep_log(caplog):
     timer = CountdownTimer(count_time)
     # Default is a trace level
     timer.sleep()
-    assert caplog.records[-1].levelname == 'TRACE'
+    assert caplog.records[-1].levelname == 'DEBUG'
     assert caplog.records[-1].message.startswith('Sleeping for')
 
     timer.restart()

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,15 +1,14 @@
 import os
-import pytest
-
-import time
 import threading
-from datetime import timezone as tz
+import time
 from datetime import datetime as dt
-from astropy import units as u
+from datetime import timezone as tz
 
-from panoptes.utils import error
-from panoptes.utils import current_time
+import pytest
+from astropy import units as u
 from panoptes.utils import CountdownTimer
+from panoptes.utils import current_time
+from panoptes.utils import error
 from panoptes.utils.time import wait_for_events
 
 
@@ -87,6 +86,20 @@ def test_countdown_timer_sleep():
     assert timer.time_left() == 0
     assert timer.expired() is True
     assert timer.sleep() is False
+
+
+def test_countdown_timer_sleep_log(caplog):
+    count_time = 1
+    timer = CountdownTimer(count_time)
+    # Default is a trace level
+    timer.sleep()
+    assert caplog.records[-1].levelname == 'TRACE'
+    assert caplog.records[-1].message.startswith('Sleeping for')
+
+    timer.restart()
+    timer.sleep(log_level='info')
+    assert caplog.records[-1].levelname == 'INFO'
+    assert caplog.records[-1].message.startswith('Sleeping for')
 
 
 @pytest.mark.slow

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -91,7 +91,7 @@ def test_countdown_timer_sleep():
 def test_countdown_timer_sleep_log(caplog):
     count_time = 1
     timer = CountdownTimer(count_time)
-    # Default is a trace level
+    # Default is a debug level
     timer.sleep()
     assert caplog.records[-1].levelname == 'DEBUG'
     assert caplog.records[-1].message.startswith('Sleeping for')


### PR DESCRIPTION
* Defaults to a `TRACE` level to not generate noise, but can be set via a parameter.

Future improvements would be to give a status update every `x` seconds if the sleep time is greater than some `y`.

Closes #258 