### PR TITLE
Add multiline option to read() method

### DIFF
--- a/src/panoptes/utils/rs232.py
+++ b/src/panoptes/utils/rs232.py
@@ -213,7 +213,7 @@ class SerialData(object):
         assert self.ser.isOpen()
         return self.ser.read(size=size)
 
-    def read(self, retry_limit=None, retry_delay=None):
+    def read(self, retry_limit=None, retry_delay=None, multiline=False):
         """Reads next line of input using readline.
 
         If no response is given, delay for retry_delay and then try to read
@@ -229,8 +229,12 @@ class SerialData(object):
 
         for _ in range(retry_limit):
             data = self.ser.readline()
-            if data:
+            if multiline:
+                data = self.ser.readlines()
+            if data and not multiline:
                 return data.decode(encoding='ascii')
+            elif data and multiline:
+                return [d.decode(encoding='ascii') for d in data]
             time.sleep(retry_delay)
         return ''
 

--- a/src/panoptes/utils/rs232.py
+++ b/src/panoptes/utils/rs232.py
@@ -231,10 +231,11 @@ class SerialData(object):
             data = self.ser.readline()
             if multiline:
                 data = self.ser.readlines()
-            if data and not multiline:
-                return data.decode(encoding='ascii')
-            elif data and multiline:
-                return [d.decode(encoding='ascii') for d in data]
+            if data:
+                if not multiline:
+                    return data.decode(encoding='ascii')
+                else:
+                    return [d.decode(encoding='ascii') for d in data]
             time.sleep(retry_delay)
         return ''
 


### PR DESCRIPTION
Hi,

This PR adds a parameter called `multiline` to the `read()` method so that it can be used for responses that have more than one line. 

This was tested on Huntsman with real hardware using the class `HuntsmanDome` of `huntsman-pocs`, more specifically `_get_shutter_status_dict` which returns more than one line. 

Please let me know any comment or suggestion.

Cheers,
Jaime A.