### PR TITLE
Add new readlines() public method

### DIFF
--- a/src/panoptes/utils/rs232.py
+++ b/src/panoptes/utils/rs232.py
@@ -234,6 +234,27 @@ class SerialData(object):
             time.sleep(retry_delay)
         return ''
 
+    def readlines(self, retry_limit=None, retry_delay=None):
+        """Reads next line of input using readline.
+
+        If no response is given, delay for retry_delay and then try to read
+        again. Fail after retry_limit attempts.
+        """
+        assert self.ser
+        assert self.ser.isOpen()
+
+        if retry_limit is None:
+            retry_limit = self.retry_limit
+        if retry_delay is None:
+            retry_delay = self.retry_delay
+
+        for _ in range(retry_limit):
+            data = self.ser.readlines()
+            if data:
+                return [d.decode(encoding='ascii') for d in data]
+            time.sleep(retry_delay)
+        return ''
+
     def get_reading(self):
         """Reads and returns a line, along with the timestamp of the read.
 

--- a/src/panoptes/utils/rs232.py
+++ b/src/panoptes/utils/rs232.py
@@ -235,25 +235,15 @@ class SerialData(object):
         return ''
 
     def readlines(self, retry_limit=None, retry_delay=None):
-        """Reads next line of input using readline.
-
-        If no response is given, delay for retry_delay and then try to read
-        again. Fail after retry_limit attempts.
+        """Reads lines of input using readlines.
         """
-        assert self.ser
-        assert self.ser.isOpen()
-
-        if retry_limit is None:
-            retry_limit = self.retry_limit
-        if retry_delay is None:
-            retry_delay = self.retry_delay
-
-        for _ in range(retry_limit):
-            data = self.ser.readlines()
-            if data:
-                return [d.decode(encoding='ascii') for d in data]
-            time.sleep(retry_delay)
-        return ''
+        lines = []
+        while True:
+            line = self.read()
+            if not line:
+                break
+            lines.append(line)
+        return lines
 
     def get_reading(self):
         """Reads and returns a line, along with the timestamp of the read.

--- a/src/panoptes/utils/rs232.py
+++ b/src/panoptes/utils/rs232.py
@@ -234,7 +234,7 @@ class SerialData(object):
             time.sleep(retry_delay)
         return ''
 
-    def readlines(self, retry_limit=None, retry_delay=None):
+    def readlines(self):
         """Reads lines of input looping read()
         """
         lines = []

--- a/src/panoptes/utils/rs232.py
+++ b/src/panoptes/utils/rs232.py
@@ -235,7 +235,7 @@ class SerialData(object):
         return ''
 
     def readlines(self, retry_limit=None, retry_delay=None):
-        """Reads lines of input using readlines.
+        """Reads lines of input looping read()
         """
         lines = []
         while True:


### PR DESCRIPTION
This PR adds a new public method called `readlines` that uses the existing method `read()` in a loop so that we can read a buffer when there is more than one line.