### PR TITLE
Processing usage updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ Changelog
 0.2.dev32
 ---------
 
+Added
+^^^^^
+
+* Added an ``RGB`` IntEnum for easy iterating and consistent array access of rgb data. #265
+* Added ``save_rgb_bg_fits`` that will save a FITS files with seven extensions: combined rgb map, and then the background and rms maps for each color. #265
+
+Changed
+^^^^^^^
+
+* ``get_rgb_background`` can accept ``fits_fn`` or ``data``. #265
+* ``get_stamp_slice`` has ``as_slices`` param added with default ``True`` for legacy behavior. If ``False`` then just the four points are returned. #265
+* Updated defaults for ``get_rgb_background``. #265
+
 
 0.2.31 - 2020-01-31
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Added
 Changed
 ^^^^^^^
 
-* ``get_rgb_background`` can accept ``fits_fn`` or ``data``. #265
+* ``get_rgb_background`` only accepts a ``data`` argument and a filename can no longer be passed. #265
 * ``get_stamp_slice`` has ``as_slices`` param added with default ``True`` for legacy behavior. If ``False`` then just the four points are returned. #265
 * Updated defaults for ``get_rgb_background``. #265
 * Test coverage will skip `noqa` markers.  #265

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,8 @@ Changed
 * ``get_rgb_background`` only accepts a ``data`` argument and a filename can no longer be passed. #265
 * Updated defaults for ``get_rgb_background``. #265
 * ``get_stamp_slice`` has ``as_slices`` param added with default ``True`` for legacy behavior. If ``False`` then just the four points are returned. #265
-* Test coverage will skip `noqa` markers.  #265
+* Test coverage will skip `noqa` markers and pytest will run all tests.  #265
+* Added `ruamel.yaml` to base dependencies instead of just ``config`` extras. #265
 
 
 0.2.31 - 2020-01-31

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,8 +15,8 @@ Changed
 ^^^^^^^
 
 * ``get_rgb_background`` only accepts a ``data`` argument and a filename can no longer be passed. #265
-* ``get_stamp_slice`` has ``as_slices`` param added with default ``True`` for legacy behavior. If ``False`` then just the four points are returned. #265
 * Updated defaults for ``get_rgb_background``. #265
+* ``get_stamp_slice`` has ``as_slices`` param added with default ``True`` for legacy behavior. If ``False`` then just the four points are returned. #265
 * Test coverage will skip `noqa` markers.  #265
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changed
 * ``get_rgb_background`` can accept ``fits_fn`` or ``data``. #265
 * ``get_stamp_slice`` has ``as_slices`` param added with default ``True`` for legacy behavior. If ``False`` then just the four points are returned. #265
 * Updated defaults for ``get_rgb_background``. #265
+* Test coverage will skip `noqa` markers.  #265
 
 
 0.2.31 - 2020-01-31

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   config-server:
-    image: gcr.io/panoptes-exp/panoptes-utils:latest
+    image: gcr.io/panoptes-exp/panoptes-utils:develop
     build:
       context: .
       dockerfile: ./Dockerfile
@@ -12,8 +12,6 @@ services:
     container_name: config-server
     hostname: config-server
     network_mode: host
-    configs:
-      - config_file
     environment:
       PANOPTES_CONFIG_HOST: 0.0.0.0
       PANOPTES_CONFIG_PORT: 6563

--- a/docker/environment.yaml
+++ b/docker/environment.yaml
@@ -11,6 +11,7 @@ dependencies:
   - loguru
   - matplotlib-base
   - numpy
+  - photutils
   - pillow
   - pip
   - python-dateutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     astropy
     click
     click-spinner
+    colorama
     loguru
     numpy
     pyserial
@@ -66,7 +67,6 @@ exclude =
 config =
     Flask
     PyYAML
-    colorama
     gevent
     python-dateutil
     requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -156,6 +156,7 @@ max-line-length = 100
 exclude_lines =
 # Have to re-enable the standard pragma
     pragma: no cover
+    noqa
 
 # Don't complain about missing debug-only code:
     def __repr__

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,7 +111,6 @@ addopts =
     --doctest-modules
     --test-databases all
     --strict-markers
-    -x
     -vv
     -ra
 norecursedirs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
     pyserial
     python-dateutil
     requests
+    ruamel.yaml
     typer
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
@@ -69,7 +70,6 @@ config =
     gevent
     python-dateutil
     requests
-    ruamel.yaml
     scalpl
 docs =
     sphinx_rtd_theme

--- a/src/panoptes/utils/images/bayer.py
+++ b/src/panoptes/utils/images/bayer.py
@@ -402,7 +402,7 @@ def get_rgb_background(fits_fn=None,
     >>> rgb_backs[0]
     <photutils.background.background_2d.Background2D...>
     >>> {color:data.background_rms_median for color, data in zip('rgb', rgb_backs)}
-    {'r': 20..., 'g': 32..., 'b': 23...}
+    {'r': 20..., 'g': 31..., 'b': 23...}
 
 
     Args:

--- a/src/panoptes/utils/images/bayer.py
+++ b/src/panoptes/utils/images/bayer.py
@@ -485,7 +485,7 @@ def get_rgb_background(data,
     return full_background
 
 
-def save_rgb_bg_fits(rgb_bg_data, output_filename, header=None, fpack=False, overwrite=True):
+def save_rgb_bg_fits(rgb_bg_data, output_filename, header=None, fpack=True, overwrite=True):
     """Save a FITS file containing a combined background as well as separate channels.
 
     Args:

--- a/src/panoptes/utils/images/bayer.py
+++ b/src/panoptes/utils/images/bayer.py
@@ -363,14 +363,14 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False, as_slice
 
 def get_rgb_background(data=None,
                        fits_fn=None,
-                       box_size=(11, 12),
-                       filter_size=(3, 3),
+                       box_size=(79, 84),
+                       filter_size=(11, 12),
                        estimator='mmm',
                        interpolator='zoom',
                        sigma=5,
                        iters=10,
                        exclude_percentile=100,
-                       return_separate=False,
+                       return_separate=True,
                        *args,
                        **kwargs
                        ):
@@ -379,6 +379,10 @@ def get_rgb_background(data=None,
     Note: This funtion does not perform any additional calibration, such as flat, bias,
     or dark correction. Either pre-process and pass the appropriate `data` or make
     sure the `fits_fn` has been processed accordingly.
+
+    By default this uses a box size of (79, 84), which gives an integer number
+    of boxes. The size of the median filter box for the low resolution background
+    is on the order of the stamp size.
 
     Most of the options are described in the `photutils.Background2D` page:
     https://photutils.readthedocs.io/en/stable/background.html#d-background-and-noise-estimation
@@ -405,10 +409,9 @@ def get_rgb_background(data=None,
         fits_fn (str): The filename of the FITS image if no `data` is given.
         data (np.array): The data to use if no `fits_fn` is provided.
         box_size (tuple, optional): The box size over which to compute the
-            2D-Background, default (11, 12), which is on the order of the stamp
-            sizes.
+            2D-Background, default (79, 84).
         filter_size (tuple, optional): The filter size for determining the median,
-            default (3, 3).
+            default (11, 12).
         estimator (str, optional): The estimator object to use, default 'mmm'.
         interpolator (str, optional): The interpolater object to user, default 'zoom'.
         sigma (int, optional): The sigma on which to filter values, default 5.

--- a/src/panoptes/utils/images/bayer.py
+++ b/src/panoptes/utils/images/bayer.py
@@ -370,7 +370,7 @@ def get_rgb_background(fits_fn=None,
                        sigma=5,
                        iters=10,
                        exclude_percentile=100,
-                       return_separate=True,
+                       return_separate=False,
                        *args,
                        **kwargs
                        ):

--- a/src/panoptes/utils/images/bayer.py
+++ b/src/panoptes/utils/images/bayer.py
@@ -396,7 +396,7 @@ def get_rgb_background(fits_fn=None,
 
     >>> rgb_back = get_rgb_background(fits_fn)
     >>> rgb_back.mean()
-    2202...
+    2184...
 
     >>> rgb_backs = get_rgb_background(fits_fn, return_separate=True)
     >>> rgb_backs[0]

--- a/src/panoptes/utils/images/bayer.py
+++ b/src/panoptes/utils/images/bayer.py
@@ -1,6 +1,8 @@
 from decimal import Decimal
+from enum import IntEnum
 
 import numpy as np
+from astropy.io import fits
 from astropy.stats import SigmaClip
 from loguru import logger
 from panoptes.utils.images import fits as fits_utils
@@ -10,6 +12,17 @@ from photutils import MeanBackground
 from photutils import MedianBackground
 from photutils import MMMBackground
 from photutils import SExtractorBackground
+
+
+class RGB(IntEnum):
+    """Helper class for array index access."""
+    RED = 0
+    R = 0
+    GREEN = 1
+    G = 1
+    G1 = 1
+    BLUE = 2
+    B = 2
 
 
 def get_rgb_data(data, separate_green=False):
@@ -189,7 +202,7 @@ def get_pixel_color(x, y):
             return 'G1'
 
 
-def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
+def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False, as_slices=True):
     """Get the slice around a given position with fixed Bayer pattern.
 
     Given an x,y pixel position, get the slice object for a stamp of a given size
@@ -280,15 +293,21 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
                [65, 66, 67, 68, 69],
                [75, 76, 77, 78, 79]])
 
-    This puts the requested pixel in the center but does not offer any guarantees about the RGGB pattern.
+    This puts the requested pixel in the center but does not offer any
+    guarantees about the RGGB pattern.
 
     Args:
         x (float): X pixel position.
         y (float): Y pixel position.
         stamp_size (tuple, optional): The size of the cutout, default (14, 14).
         ignore_superpixel (bool): If superpixels should be ignored, default False.
+        as_slices (bool): Return slice objects, default True. Otherwise returns:
+            y_min, y_max, x_min, x_max
     Returns:
-        `slice`: A slice object for the data.
+        `list(slice, slice)` or `list(int, int, int, int)`: A list of row and
+            column slice objects or a list defining the bounding box:
+            y_min, y_max, x_min, x_max. Return type depends on the `as_slices`
+            parameter and defaults to a list of two slices.
     """
     # Make sure requested size can have superpixels on each side.
     if not ignore_superpixel:
@@ -336,23 +355,30 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False):
 
     logger.debug(f'x_min={x_min}, x_max={x_max}, y_min={y_min}, y_max={y_max}')
 
-    return (slice(y_min, y_max), slice(x_min, x_max))
+    if as_slices:
+        return slice(y_min, y_max), slice(x_min, x_max)
+    else:
+        return y_min, y_max, x_min, x_max
 
 
-def get_rgb_background(fits_fn,
-                       box_size=(84, 84),
+def get_rgb_background(data=None,
+                       fits_fn=None,
+                       box_size=(11, 12),
                        filter_size=(3, 3),
-                       camera_bias=0,
-                       estimator='mean',
+                       estimator='mmm',
                        interpolator='zoom',
                        sigma=5,
-                       iters=5,
+                       iters=10,
                        exclude_percentile=100,
                        return_separate=False,
                        *args,
                        **kwargs
                        ):
     """Get the background for each color channel.
+
+    Note: This funtion does not perform any additional calibration, such as flat, bias,
+    or dark correction. Either pre-process and pass the appropriate `data` or make
+    sure the `fits_fn` has been processed accordingly.
 
     Most of the options are described in the `photutils.Background2D` page:
     https://photutils.readthedocs.io/en/stable/background.html#d-background-and-noise-estimation
@@ -376,17 +402,17 @@ def get_rgb_background(fits_fn,
 
 
     Args:
-        fits_fn (str): The filename of the FITS image.
+        fits_fn (str): The filename of the FITS image if no `data` is given.
+        data (np.array): The data to use if no `fits_fn` is provided.
         box_size (tuple, optional): The box size over which to compute the
-            2D-Background, default (84, 84).
+            2D-Background, default (11, 12), which is on the order of the stamp
+            sizes.
         filter_size (tuple, optional): The filter size for determining the median,
             default (3, 3).
-        camera_bias (int, optional): The built-in camera bias, default 0. A zero camera
-            bias means the bias will be considered as part of the background.
-        estimator (str, optional): The estimator object to use, default 'median'.
+        estimator (str, optional): The estimator object to use, default 'mmm'.
         interpolator (str, optional): The interpolater object to user, default 'zoom'.
         sigma (int, optional): The sigma on which to filter values, default 5.
-        iters (int, optional): The number of iterations to sigma filter, default 5.
+        iters (int, optional): The number of iterations to sigma filter, default 10.
         exclude_percentile (int, optional): The percentage of the data (per channel)
             that can be masked, default 100 (i.e. all).
         return_separate (bool, optional): If the function should return a separate array
@@ -395,14 +421,13 @@ def get_rgb_background(fits_fn,
         **kwargs: Description
 
     Returns:
-        `numpy.array`|list: Either a single numpy array representing the entire
+        `numpy.array`|list(Background2D): Either a single numpy array representing the entire
           background, or a list of masked numpy arrays in RGB order. The background
           for each channel has full interploation across all pixels, but the mask covers
           them.
     """
-    logger.info(f"Getting background for {fits_fn}")
-    logger.debug(
-        f"{estimator} {interpolator} {box_size} {filter_size} {camera_bias} σ={sigma} n={iters}")
+    logger.debug(f"Getting background for {fits_fn or data.shape}")
+    logger.debug(f"{estimator} {interpolator} {box_size} {filter_size} σ={sigma} n={iters}")
 
     estimators = {
         'sexb': SExtractorBackground,
@@ -417,14 +442,24 @@ def get_rgb_background(fits_fn,
     bkg_estimator = estimators[estimator]()
     interp = interpolators[interpolator]()
 
-    data = fits_utils.getdata(fits_fn) - camera_bias
+    # Use data if given, but warn if also given other options.
+    if data is not None:
+        if fits_fn:
+            logger.warning(f'Both data and fits_fn given, using data.')
+    else:
+        # Data not given, ensure we have filename and set zero camera_bias if not given.
+        if fits_fn is None:
+            raise ValueError('Need either data or fits_fn')
+
+        data = fits_utils.getdata(fits_fn)
 
     # Get the data per color channel.
+    logger.debug(f'Getting RGB background data')
     rgb_data = get_rgb_data(data)
 
     backgrounds = list()
-    for color, color_data in zip(['R', 'G', 'B'], rgb_data):
-        logger.debug(f'Performing background {color} for {fits_fn}')
+    for color, color_data in zip(RGB, rgb_data):
+        logger.debug(f'Calculating background for {color.name.lower()} pixels')
 
         bkg = Background2D(color_data,
                            box_size,
@@ -435,13 +470,14 @@ def get_rgb_background(fits_fn,
                            mask=color_data.mask,
                            interpolator=interp)
 
-        # Create a masked array for the background
+        logger.debug(f"{color.name.lower()}: {bkg.background_median:.02f} "
+                     f"RMS: {bkg.background_rms_median:.02f}")
+
         if return_separate:
             backgrounds.append(bkg)
         else:
+            # Create a masked array for the background
             backgrounds.append(np.ma.array(data=bkg.background, mask=color_data.mask))
-        logger.debug(
-            f"{color} Value: {bkg.background_median:.02f} RMS: {bkg.background_rms_median:.02f}")
 
     if return_separate:
         return backgrounds
@@ -450,3 +486,51 @@ def get_rgb_background(fits_fn,
     full_background = np.ma.array(backgrounds).sum(0).filled(0)
 
     return full_background
+
+
+def save_rgb_bg_fits(rgb_bg_data, output_filename, header=None, fpack=True, overwrite=True):
+    """Save a FITS file containing a combined background as well as separate channels.
+
+    Args:
+        rgb_bg_data (list[photutils.Background2D]): The RGB background data as
+            returned by calling `panoptes.utils.images.bayer.get_rgb_background`
+            with `return_separate=True`.
+        output_filename (str): The output name for the FITS file.
+        header (astropy.io.fits.Header): FITS header to be saved with the file.
+        fpack (bool): If the FITS file should be compressed, default True.
+        overwrite (bool): If FITS file should be overwritten, default True.
+    """
+
+    # Get combined data for Primary HDU
+    combined_bg = np.array([np.ma.array(data=d.background, mask=d.mask).filled(0)
+                            for d in rgb_bg_data]).sum(0)
+
+    # Save as ing16.
+    header['BITPIX'] = 16
+
+    # Combined background is primary hdu.
+    primary = fits.PrimaryHDU(combined_bg, header=header)
+    primary.scale('int16')
+    hdu_list = [primary]
+
+    for color, bg in zip(RGB, rgb_bg_data):
+        h0 = fits.Header()
+        h0['COLOR'] = f'{color.name.lower()}'
+
+        h0['IMGTYPE'] = 'background'
+        img0 = fits.ImageHDU(bg.background, header=h0)
+        img0.scale('int16')
+        hdu_list.append(img0)
+
+        h0['IMGTYPE'] = 'background_rms'
+        img1 = fits.ImageHDU(bg.background_rms, header=h0)
+        img1.scale('int16')
+        hdu_list.append(img1)
+
+    hdul = fits.HDUList(hdu_list)
+    hdul.writeto(output_filename, overwrite=overwrite)
+
+    if fpack:
+        output_filename = fits_utils.fpack(output_filename)
+
+    return output_filename

--- a/src/panoptes/utils/images/bayer.py
+++ b/src/panoptes/utils/images/bayer.py
@@ -390,23 +390,28 @@ def get_rgb_background(fits_fn=None,
     Most of the options are described in the `photutils.Background2D` page:
     https://photutils.readthedocs.io/en/stable/background.html#d-background-and-noise-estimation
 
+    >>> from panoptes.utils.images.bayer import RGB
     >>> from panoptes.utils.images import fits as fits_utils
     >>> fits_fn = getfixture('solved_fits_file')
+    >>> camera_bias = 2048
+    >>> data = fits_utils.getdata(fits_fn) - camera_bias
 
-    >>> data = fits_utils.getdata(fits_fn)
-    >>> data.mean()
-    2236...
-
-    >>> rgb_back = get_rgb_background(fits_fn)
+    >> The default is to return a single array for the background.
+    >>> rgb_back = get_rgb_background(data=data)
     >>> rgb_back.mean()
-    2184...
+    136...
+    >>> rgb_back.std()
+    36...
 
-    >>> rgb_backs = get_rgb_background(fits_fn, return_separate=True)
-    >>> rgb_backs[0]
-    <photutils.background.background_2d.Background2D...>
-    >>> {color:data.background_rms_median for color, data in zip('rgb', rgb_backs)}
-    {'r': 20..., 'g': 31..., 'b': 23...}
+    >>> # Can also return the Background2D objects, which is the input to save_rgb_bg_fits
+    >>> rgb_backs = get_rgb_background(data=data, return_separate=True)
+    >>> rgb_backs
+    [<photutils.background.background_2d.Background2D at ...>,
+     <photutils.background.background_2d.Background2D at ...>,
+     <photutils.background.background_2d.Background2D at ...>]
 
+    >>> {color.name:int(rgb_back[color].mean()) for color in RGB}
+    {'RED': 145, 'GREEN': 127, 'BLUE': 145}
 
     Args:
         fits_fn (str): The filename of the FITS image if no `data` is given.

--- a/src/panoptes/utils/images/bayer.py
+++ b/src/panoptes/utils/images/bayer.py
@@ -361,8 +361,8 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False, as_slice
         return y_min, y_max, x_min, x_max
 
 
-def get_rgb_background(data=None,
-                       fits_fn=None,
+def get_rgb_background(fits_fn=None,
+                       data=None,
                        box_size=(79, 84),
                        filter_size=(11, 12),
                        estimator='mmm',

--- a/src/panoptes/utils/images/bayer.py
+++ b/src/panoptes/utils/images/bayer.py
@@ -406,7 +406,7 @@ def get_rgb_background(data,
     >>> # Can also return the Background2D objects, which is the input to save_rgb_bg_fits
     >>> rgb_backs = get_rgb_background(data, return_separate=True)
     >>> rgb_backs[RGB.RED]
-    <photutils.background.background_2d.Background2D at ...>
+    <photutils.background.background_2d.Background2D...>
 
     >>> {color.name:int(rgb_back[color].mean()) for color in RGB}
     {'RED': 145, 'GREEN': 127, 'BLUE': 145}

--- a/src/panoptes/utils/images/bayer.py
+++ b/src/panoptes/utils/images/bayer.py
@@ -437,7 +437,7 @@ def get_rgb_background(data,
           them.
     """
     logger.debug("RGB background subtraction")
-    logger.debug(f"{estimator=} {interpolator=} {box_size=} {filter_size=} {sigma=} {iters=}")
+    logger.debug(f"{estimator} {interpolator} {box_size} {filter_size} {sigma} {iters}")
 
     estimators = {
         'sexb': SExtractorBackground,

--- a/src/panoptes/utils/images/bayer.py
+++ b/src/panoptes/utils/images/bayer.py
@@ -485,7 +485,7 @@ def get_rgb_background(data,
     return full_background
 
 
-def save_rgb_bg_fits(rgb_bg_data, output_filename, header=None, fpack=True, overwrite=True):
+def save_rgb_bg_fits(rgb_bg_data, output_filename, header=None, fpack=False, overwrite=True):
     """Save a FITS file containing a combined background as well as separate channels.
 
     Args:

--- a/src/panoptes/utils/images/bayer.py
+++ b/src/panoptes/utils/images/bayer.py
@@ -267,6 +267,9 @@ def get_stamp_slice(x, y, stamp_size=(14, 14), ignore_superpixel=False, as_slice
                [54, 55, 56, 57, 58, 59],
                [64, 65, 66, 67, 68, 69],
                [74, 75, 76, 77, 78, 79]])
+        >>> # Return y_min, y_max, x_min, x_max
+        >>> bayer.get_stamp_slice(x, y, stamp_size=(6, 6), as_slices=False)
+        (2, 8, 4, 10)
 
     The original index had a value of `57`, which is within the center superpixel.
 
@@ -447,7 +450,7 @@ def get_rgb_background(fits_fn=None,
 
     # Use data if given, but warn if also given other options.
     if data is not None:
-        if fits_fn:
+        if fits_fn:  # noqa
             logger.warning(f'Both data and fits_fn given, using data.')
     else:
         # Data not given, ensure we have filename and set zero camera_bias if not given.
@@ -507,6 +510,8 @@ def save_rgb_bg_fits(rgb_bg_data, output_filename, header=None, fpack=True, over
     # Get combined data for Primary HDU
     combined_bg = np.array([np.ma.array(data=d.background, mask=d.mask).filled(0)
                             for d in rgb_bg_data]).sum(0)
+
+    header = header or fits.Header()
 
     # Save as ing16.
     header['BITPIX'] = 16

--- a/src/panoptes/utils/images/bayer.py
+++ b/src/panoptes/utils/images/bayer.py
@@ -405,10 +405,8 @@ def get_rgb_background(data,
 
     >>> # Can also return the Background2D objects, which is the input to save_rgb_bg_fits
     >>> rgb_backs = get_rgb_background(data, return_separate=True)
-    >>> rgb_backs
-    [<photutils.background.background_2d.Background2D at ...>,
-     <photutils.background.background_2d.Background2D at ...>,
-     <photutils.background.background_2d.Background2D at ...>]
+    >>> rgb_backs[RGB.RED]
+    <photutils.background.background_2d.Background2D at ...>
 
     >>> {color.name:int(rgb_back[color].mean()) for color in RGB}
     {'RED': 145, 'GREEN': 127, 'BLUE': 145}

--- a/src/panoptes/utils/images/plot.py
+++ b/src/panoptes/utils/images/plot.py
@@ -8,8 +8,7 @@ from matplotlib.figure import Figure
 from matplotlib import cm
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import numpy as np
-from astropy.visualization import ImageNormalize, LinearStretch, LogStretch, MinMaxInterval, \
-    simple_norm
+from astropy.visualization import ImageNormalize, LinearStretch, LogStretch, MinMaxInterval
 
 rc('animation', html='html5')
 
@@ -221,80 +220,4 @@ def show_stamps(pscs,
         except Exception as e:
             warn("Can't save figure: {}".format(e))
 
-    return fig
-
-
-def plot_stamp(picid,
-               data,
-               metadata,
-               frame_idx=None,
-               show_mean=False,
-               show_all=False,
-               cmap=None,
-               stretch='sqrt',
-               ):
-    cmap = cmap or get_palette('viridis')
-
-    picid = metadata.picid.iloc[0]
-
-    fig = Figure()
-    FigureCanvas(fig)
-    fig.set_figheight(4)
-    fig.set_figwidth(4)
-
-    nrows = 1
-    ncols = 1
-    ax = fig.add_subplot(nrows, ncols, 1)
-
-    if frame_idx:
-        stamp = data.iloc[frame_idx]
-    else:
-        stamp = data
-
-    # Get the frame bounds on full image.
-    y0, y1, x0, x1 = metadata.filter(regex='stamp').iloc[frame_idx]
-
-    # Get peak location on stamp.
-    x_peak = metadata.catalog_wcs_x_int.iloc[frame_idx] - x0
-    y_peak = metadata.catalog_wcs_y_int.iloc[frame_idx] - y0
-
-    # Plot stamp.
-    norm = simple_norm(stamp, stretch)
-    im0 = ax.imshow(stamp, norm=norm, cmap=cmap, origin='lower')
-    add_colorbar(im0)
-
-    # Mean location
-    if show_mean:
-        ax.scatter(metadata.catalog_wcs_x_mean.astype('int') - x0,
-                   metadata.catalog_wcs_y_mean.astype('int') - y0,
-                   marker='x',
-                   color='lightgreen',
-                   edgecolors='red',
-                   s=250,
-                   label='Catalog - mean position')
-
-    if show_all:
-        ax.scatter(metadata.catalog_wcs_x_int - x0,
-                   metadata.catalog_wcs_y_int - y0,
-                   marker='x',
-                   color='orange',
-                   edgecolors='orange',
-                   s=100,
-                   label='Catalog - other frames')
-
-    # Star catalog location for current frame
-    ax.scatter(x_peak, y_peak, marker='*', color='yellow', edgecolors='black', s=200,
-               label='Catalog - current frame')
-
-    add_pixel_grid(ax,
-                   grid_height=data.shape[0],
-                   grid_width=data.shape[1],
-                   show_superpixel=True,
-                   major_alpha=0.3, minor_alpha=0.0, )
-    ax.set_xticklabels([t for t in range(int(x0), int(x1) + 2, 2)], rotation=45)
-    ax.set_yticklabels([t for t in range(int(y0), int(y1) + 2, 2)])
-
-    ax.legend(loc=3)
-
-    ax.set_title(f'PICID: {picid} Frame: {frame_idx} / {len(metadata)}')
     return fig

--- a/src/panoptes/utils/images/plot.py
+++ b/src/panoptes/utils/images/plot.py
@@ -2,7 +2,6 @@ from copy import copy
 from warnings import warn
 
 from matplotlib import rc
-from matplotlib import pyplot as plt
 from matplotlib import animation
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
@@ -11,7 +10,6 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 import numpy as np
 from astropy.visualization import ImageNormalize, LinearStretch, LogStretch, MinMaxInterval, \
     simple_norm
-from panoptes.utils.images import bayer
 
 rc('animation', html='html5')
 
@@ -299,44 +297,4 @@ def plot_stamp(picid,
     ax.legend(loc=3)
 
     ax.set_title(f'PICID: {picid} Frame: {frame_idx} / {len(metadata)}')
-    return fig
-
-
-def plot_background(rgb_bg_data, title=None):
-    """ Plot the RGB backgrounds from `Background2d` objects.
-
-    Args:
-        rgb_bg_data (list[photutils.Background2D]): The RGB background data as
-            returned by calling `panoptes.utils.images.bayer.get_rgb_background`
-            with `return_separate=True`.
-        title (str): The title for the plot, default None.
-
-    """
-
-    nrows = 2
-    ncols = 3
-
-    fig, axes = plt.subplots(nrows=nrows, ncols=ncols, sharex=True, sharey=True)
-    fig.set_facecolor('white')
-
-    for color in bayer.RGB:
-        d0 = rgb_bg_data[color]
-        ax0 = axes[0][color]
-        ax1 = axes[1][color]
-
-        ax0.set_title(f'{color.name.title()} (med {d0.background_median:.02f} ADU)')
-        im = ax0.imshow(d0.background, cmap=f'{color.name.title()}s_r', origin='lower')
-        add_colorbar(im)
-
-        ax1.set_title(f'{color.name.title()} rms (med {d0.background_rms_median:.02f} ADU)')
-        im = ax1.imshow(d0.background_rms, cmap=f'{color.name.title()}s_r', origin='lower')
-        add_colorbar(im)
-
-        ax0.set_axis_off()
-        ax1.set_axis_off()
-
-    if title:
-        fig.suptitle(title)
-
-    fig.set_size_inches(11, 5)
     return fig

--- a/tests/images/test_bayer.py
+++ b/tests/images/test_bayer.py
@@ -61,11 +61,6 @@ def test_get_rgb_4d_data():
         bayer.get_rgb_data(data)
 
 
-def test_rgb_bg_fail():
-    with pytest.raises(ValueError):
-        bayer.get_rgb_background()
-
-
 def test_get_pixel_color():
     """
         From the docstring:

--- a/tests/images/test_bayer.py
+++ b/tests/images/test_bayer.py
@@ -136,7 +136,7 @@ def test_save_rgb_bg_fits(solved_fits_file, tmpdir):
 
     rgb_data = bayer.get_rgb_background(d0, return_separate=True)
     bayer.save_rgb_bg_fits(rgb_data, output_filename=str(temp_fn), header=h0, fpack=False)
-    assert fits_utils.getval(solved_fits_file, 'test') is True
+    assert fits_utils.getval(str(temp_fn), 'test') is True
 
     with pytest.raises(ValueError):
         bayer.save_rgb_bg_fits(rgb_data, output_filename=str(temp_fn), header=h0, fpack=False,
@@ -146,4 +146,4 @@ def test_save_rgb_bg_fits(solved_fits_file, tmpdir):
 
     # Didn't use our header.
     with pytest.raises(KeyError):
-        fits_utils.getval(solved_fits_file, 'test')
+        fits_utils.getval(str(temp_fn), 'test')

--- a/tests/images/test_bayer.py
+++ b/tests/images/test_bayer.py
@@ -127,14 +127,14 @@ def test_get_stamp_slice_fail():
         bayer.get_stamp_slice(512, 514, stamp_size=(100, 100))
 
 
-def test_save_rgb_fits(solved_fits_file, tmpdir):
+def test_save_rgb_bg_fits(solved_fits_file, tmpdir):
     d0, h0 = fits_utils.getdata(solved_fits_file, header=True)
 
     temp_fn = tmpdir / 'temp.fits'
 
     h0['test'] = True
 
-    rgb_data = bayer.get_rgb_data(data=d0)
+    rgb_data = bayer.get_rgb_background(d0, return_separate=True)
     bayer.save_rgb_bg_fits(rgb_data, output_filename=str(temp_fn), header=h0, fpack=False)
     assert fits_utils.getval(solved_fits_file, 'test') is True
 

--- a/tests/images/test_bayer.py
+++ b/tests/images/test_bayer.py
@@ -142,7 +142,8 @@ def test_save_rgb_bg_fits(solved_fits_file, tmpdir):
         bayer.save_rgb_bg_fits(rgb_data, output_filename=str(temp_fn), header=h0, fpack=False,
                                overwrite=False)
 
-    bayer.save_rgb_bg_fits(rgb_data, output_filename=str(temp_fn), fpack=False, overwrite=True)
+    temp_fn = bayer.save_rgb_bg_fits(rgb_data, output_filename=str(temp_fn), fpack=True,
+                                     overwrite=True)
 
     # Didn't use our header.
     with pytest.raises(KeyError):

--- a/tests/images/test_bayer.py
+++ b/tests/images/test_bayer.py
@@ -138,7 +138,7 @@ def test_save_rgb_bg_fits(solved_fits_file, tmpdir):
     bayer.save_rgb_bg_fits(rgb_data, output_filename=str(temp_fn), header=h0, fpack=False)
     assert fits_utils.getval(str(temp_fn), 'test') is True
 
-    with pytest.raises(ValueError):
+    with pytest.raises(OSError):
         bayer.save_rgb_bg_fits(rgb_data, output_filename=str(temp_fn), header=h0, fpack=False,
                                overwrite=False)
 

--- a/tests/images/test_bayer.py
+++ b/tests/images/test_bayer.py
@@ -63,7 +63,7 @@ def test_get_rgb_4d_data():
 
 def test_rgb_bg_fail():
     with pytest.raises(ValueError):
-        bayer.get_rgb_data()
+        bayer.get_rgb_background()
 
 
 def test_get_pixel_color():

--- a/tests/images/test_bayer.py
+++ b/tests/images/test_bayer.py
@@ -128,7 +128,7 @@ def test_get_stamp_slice_fail():
 
 
 def test_save_rgb_fits(solved_fits_file, tmpdir):
-    d0, h0 = fits_utils.getdata(solved_fits_file)
+    d0, h0 = fits_utils.getdata(solved_fits_file, header=True)
 
     temp_fn = tmpdir / 'temp.fits'
 


### PR DESCRIPTION
Misc edits during processing

* Default docker compose file to `develop` tag.
* Add `photutils` dependency in docker.
* Added an `RGB` IntEnum for easy iterating and consistent array access of rgb data.
* `get_stamp_slice` has `as_slices` param added with default `True` for legacy behavior. If `False` then just the four points are returned.
* `get_rgb_background` only accepts `data` as an argument.
* Updated defaults for `get_rgb_background`.
* Added `save_rgb_bg_fits` that will save a FITS files with seven extensions: combined rgb map, and then the background and rms maps for each color.
* `ruamel.yaml` added to base dependencies for use in serializes.

