### PR TITLE
Fix solve field timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-0.2.dev32
+0.2.32dev
 ---------
 
 Added
@@ -19,6 +19,11 @@ Changed
 * ``get_stamp_slice`` has ``as_slices`` param added with default ``True`` for legacy behavior. If ``False`` then just the four points are returned. #265
 * Test coverage will skip `noqa` markers and pytest will run all tests.  #265
 * Added `ruamel.yaml` to base dependencies instead of just ``config`` extras. #265
+
+Fixed
+^^^^^
+
+* The `timeout` parameter is now passed from `get_solve_field` to `solve_field`. #266
 
 
 0.2.31 - 2020-01-31

--- a/src/panoptes/utils/images/fits.py
+++ b/src/panoptes/utils/images/fits.py
@@ -135,8 +135,6 @@ def get_solve_field(fname, replace=True, overwrite=True, timeout=30, **kwargs):
     skip_solved = kwargs.get('skip_solved', True)
 
     out_dict = {}
-    output = None
-    errs = None
 
     header = getheader(fname)
     wcs = WCS(header)
@@ -162,9 +160,9 @@ def get_solve_field(fname, replace=True, overwrite=True, timeout=30, **kwargs):
         was_compressed = True
 
     logger.debug(f'Use solve arguments: {kwargs!r}')
-    proc = solve_field(fname, **kwargs)
+    proc = solve_field(fname, timeout=timeout, **kwargs)
     try:
-        output, errs = proc.communicate(timeout=timeout)
+        output, errs = proc.communicate(timeout=(timeout + 5))
     except subprocess.TimeoutExpired:
         proc.kill()
         output, errs = proc.communicate()

--- a/src/panoptes/utils/images/fits.py
+++ b/src/panoptes/utils/images/fits.py
@@ -162,6 +162,7 @@ def get_solve_field(fname, replace=True, overwrite=True, timeout=30, **kwargs):
     logger.debug(f'Use solve arguments: {kwargs!r}')
     proc = solve_field(fname, timeout=timeout, **kwargs)
     try:
+        # Timeout plus a small buffer.
         output, errs = proc.communicate(timeout=(timeout + 5))
     except subprocess.TimeoutExpired:
         proc.kill()


### PR DESCRIPTION
The `timeout` parameter from `get_solve_field` was being used only for the process timeout and wasn't being passed to `solve_field` for actual solving timeout. Default timeout (i.e. `cpulimit`) for `solve_field` was at 15 seconds.