### PR TITLE
Lookup serial port from vendor and product id

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,7 @@ Changelog
 Added
 ^^^^^
 
-* `panoptes.utils.rs232.find_serial_port` can be used to look up a serial port from the vendor and product hex ids.
-
+* `panoptes.utils.rs232.find_serial_port` can be used to look up a serial port from the vendor and product hex ids.  #269
 
 0.2.32 - 2020-02-28
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Changelog
 0.2.32dev
 ---------
 
+Added
+^^^^^
+
+* `panoptes.utils.rs232.find_serial_port` can be used to look up a serial port from the vendor and product hex ids.
+
 
 0.2.32 - 2020-02-28
 -------------------

--- a/src/panoptes/utils/rs232.py
+++ b/src/panoptes/utils/rs232.py
@@ -36,8 +36,8 @@ def find_serial_port(vendor_id, product_id, return_all=False):
         panoptes.utils.error.NotFound: NotFound: No serial ports for vendor_id=4660 and product_id=17185
 
     Args:
-        vendor_id (hex): The vendor id string in hex.
-        product_id (hex): The product id string in hex.
+        vendor_id (int): The vendor id, can be hex or int.
+        product_id (hex): The product id, can be hex or int.
         return_all (bool): If more than one serial port matches, return all devices, default False.
 
     Returns:

--- a/src/panoptes/utils/rs232.py
+++ b/src/panoptes/utils/rs232.py
@@ -1,5 +1,3 @@
-"""Provides SerialData, a PySerial wrapper."""
-
 import operator
 import time
 from contextlib import suppress
@@ -11,8 +9,6 @@ from panoptes.utils import serializers
 from serial.tools.list_ports import comports as get_comports
 
 
-# Note: get_serial_port_info is replaced by tests to override the normal
-# behavior, so don't change the name without fixing the tests.
 def get_serial_port_info():
     """Returns the serial ports defined on the system.
 
@@ -20,6 +16,43 @@ def get_serial_port_info():
         https://github.com/pyserial/pyserial/blob/master/serial/tools/list_ports_common.py
     """
     return sorted(get_comports(), key=operator.attrgetter('device'))
+
+
+def find_serial_port(vendor_id, product_id, return_all=False):
+    """Finds the serial port that matches the given vendor and product id.
+
+    .. doctest::
+
+        >>> from panoptes.utils.rs232 import find_serial_port
+        >>> vendor_id = 0x2a03  # arduino
+        >>> product_id = 0x0043 # Uno Rev 3
+        >>> find_serial_port(vendor_id, product_id)  # pragma: no test
+        '/dev/ttyACM0'
+
+        >>> # Raises error when not found.
+        >>> find_serial_port(0x1234, 0x4321)
+        Traceback (most recent call last):
+          ...
+        panoptes.utils.error.NotFound: NotFound: No serial ports for vendor_id=4660 and product_id=17185
+
+    Args:
+        vendor_id (hex): The vendor id string in hex.
+        product_id (hex): The product id string in hex.
+        return_all (bool): If more than one serial port matches, return all devices, default False.
+
+    Returns:
+        str or list
+    """
+    # Get all serial ports.
+    matched_ports = [p for p in get_serial_port_info() if
+                     p.vid == vendor_id and p.pid == product_id]
+
+    if len(matched_ports) == 1:
+        return matched_ports[0].device
+    elif return_all:
+        return matched_ports
+    else:
+        raise error.NotFound(f'No serial ports for {vendor_id=:x} and {product_id=:x}')
 
 
 class SerialData(object):

--- a/src/panoptes/utils/rs232.py
+++ b/src/panoptes/utils/rs232.py
@@ -41,7 +41,7 @@ def find_serial_port(vendor_id, product_id, return_all=False):
         return_all (bool): If more than one serial port matches, return all devices, default False.
 
     Returns:
-        str or list
+        str or list: Either the path to the detected port or a list of all comports that match.
     """
     # Get all serial ports.
     matched_ports = [p for p in get_serial_port_info() if

--- a/src/panoptes/utils/rs232.py
+++ b/src/panoptes/utils/rs232.py
@@ -26,7 +26,7 @@ def find_serial_port(vendor_id, product_id, return_all=False):
         >>> from panoptes.utils.rs232 import find_serial_port
         >>> vendor_id = 0x2a03  # arduino
         >>> product_id = 0x0043 # Uno Rev 3
-        >>> find_serial_port(vendor_id, product_id)  # pragma: no test
+        >>> find_serial_port(vendor_id, product_id)  # doctest: +SKIP
         '/dev/ttyACM0'
 
         >>> # Raises error when not found.

--- a/src/panoptes/utils/rs232.py
+++ b/src/panoptes/utils/rs232.py
@@ -18,7 +18,7 @@ def get_serial_port_info():
     return sorted(get_comports(), key=operator.attrgetter('device'))
 
 
-def find_serial_port(vendor_id, product_id, return_all=False):
+def find_serial_port(vendor_id, product_id, return_all=False):  # pragma: no cover
     """Finds the serial port that matches the given vendor and product id.
 
     .. doctest::

--- a/src/panoptes/utils/rs232.py
+++ b/src/panoptes/utils/rs232.py
@@ -37,7 +37,7 @@ def find_serial_port(vendor_id, product_id, return_all=False):
 
     Args:
         vendor_id (int): The vendor id, can be hex or int.
-        product_id (hex): The product id, can be hex or int.
+        product_id (int): The product id, can be hex or int.
         return_all (bool): If more than one serial port matches, return all devices, default False.
 
     Returns:
@@ -52,7 +52,8 @@ def find_serial_port(vendor_id, product_id, return_all=False):
     elif return_all:
         return matched_ports
     else:
-        raise error.NotFound(f'No serial ports for {vendor_id=:x} and {product_id=:x}')
+        raise error.NotFound(
+            f'No serial ports for vendor_id={vendor_id:x} and product_id={product_id:x}')
 
 
 class SerialData(object):


### PR DESCRIPTION
Small utility function to look up a serial device path by vendor and product id.  Can also return all `comport` devices that match if multiple devices with same vendor and product id are plugged in.