### PR TITLE
Docker cleanup - The Never Ending Story

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,11 +12,9 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ARG panuser=pocs-user
 ARG userid=1000
 ARG pip_install_extras="[config]"
-ARG panoptes_utils_dir="/panoptes"
 
 ENV PANUSER $panuser
 ENV USERID $userid
-ENV PANOPTES_UTILS_DIR $panoptes_utils_dir
 ENV PATH "/home/${PANUSER}/.local/bin:$PATH"
 
 # Install system dependencies as root user.
@@ -52,12 +50,15 @@ RUN echo "Installing conda via miniforge" && \
     /conda/bin/conda init bash && \
     rm install-miniforge.sh
 
-WORKDIR "${PANOPTES_UTILS_DIR}"
+ARG app_dir=/panoptes-utils
+ENV APP_DIR $app_dir
+
+WORKDIR "${APP_DIR}"
 COPY docker/environment.yaml .
 COPY docker/docker-compose.yaml .
 RUN /conda/bin/conda-env update -n base -f environment.yaml
 
-RUN echo "Installing panoptes-pocs module with ${pip_install_extras}" && \
+RUN echo "Installing panoptes-utils module with ${pip_install_extras}" && \
     /conda/bin/pip install "panoptes-utils${pip_install_extras}" && \
     # Cleanup
     /conda/bin/pip cache purge && \
@@ -67,6 +68,6 @@ RUN echo "Installing panoptes-pocs module with ${pip_install_extras}" && \
     sudo apt-get --yes clean && \
     sudo rm -rf /var/lib/apt/lists/*
 
-# We are still the PANUSER in the PANOPTES_UTILS_DIR.
+# We are still the PANUSER.
 ENTRYPOINT [ "/usr/bin/env", "bash", "-ic" ]
 CMD [ "panoptes-config-server", "--help" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,11 +12,14 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ARG panuser=pocs-user
 ARG userid=1000
 ARG pip_install_extras="[config]"
+ARG panoptes_utils_dir="/panoptes"
 
 ENV PANUSER $panuser
 ENV USERID $userid
+ENV PANOPTES_UTILS_DIR $panoptes_utils_dir
+ENV PATH "/home/${PANUSER}/.local/bin:$PATH"
 
-# Install system dependencies.
+# Install system dependencies as root user.
 RUN echo "Building from ${image_name}:${image_tag}" && \
     apt-get update && apt-get install --no-install-recommends --yes \
         bzip2 ca-certificates \
@@ -33,6 +36,7 @@ RUN echo "Building from ${image_name}:${image_tag}" && \
     mkdir -p "/home/${panuser}/.ssh" && \
     echo "Host localhost\n\tStrictHostKeyChecking no\n" >> "/home/${panuser}/.ssh/config"
 
+# Change to our app user.
 USER "${userid}"
 
 # Miniconda
@@ -45,12 +49,13 @@ RUN echo "Installing conda via miniforge" && \
         -O install-miniforge.sh && \
     /bin/sh install-miniforge.sh -b -f -p /conda && \
     # Initialize conda for the shells.
-    /conda/bin/conda init bash
+    /conda/bin/conda init bash && \
+    rm install-miniforge.sh
 
-ENV PATH "/home/${PANUSER}/.local/bin:$PATH"
-
+WORKDIR "${PANOPTES_UTILS_DIR}"
 COPY docker/environment.yaml .
-RUN /conda/bin/conda env update -n base -f environment.yaml
+COPY docker/docker-compose.yaml .
+RUN /conda/bin/conda-env update -n base -f environment.yaml
 
 RUN echo "Installing panoptes-pocs module with ${pip_install_extras}" && \
     /conda/bin/pip install "panoptes-utils${pip_install_extras}" && \
@@ -62,9 +67,6 @@ RUN echo "Installing panoptes-pocs module with ${pip_install_extras}" && \
     sudo apt-get --yes clean && \
     sudo rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
-COPY docker/docker-compose.yaml .
-
-# We are still the PANUSER.
+# We are still the PANUSER in the PANOPTES_UTILS_DIR.
 ENTRYPOINT [ "/usr/bin/env", "bash", "-ic" ]
 CMD [ "panoptes-config-server", "--help" ]

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -2,7 +2,6 @@ options:
   substitutionOption: "ALLOW_LOOSE"
 timeout: 18000s  # 5 hours
 
-
 substitutions:
   _PLATFORM: linux/arm64,linux/amd64
 


### PR DESCRIPTION
Working directories for PANOPTES will follow the repo name for consistency, so everything from here will go into `/panoptes-utils`.

Also remove some build files from final image.