### PR TITLE
Config client updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,16 @@ Added
 ^^^^^
 
 * ``panoptes.utils.rs232.find_serial_port()`` can be used to look up a serial port from the vendor and product hex ids.  #269
-* ``pnaoptes.utils.config.config.client.get_config()`` changed so ``default`` is the second parameter. #272
+
+Changed
+^^^^^^^
+
+* ``panoptes.utils.config.config.client.get_config()`` changed so ``default`` is the second parameter and function made less noisy overall. #272
+
+Removed
+^^^^^^^
+
+* ``panoptes.utils.logging`` which is just replaced by ``from loguru import logger``. # 272
 
 0.2.32 - 2020-02-28
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,8 @@ Changelog
 Added
 ^^^^^
 
-* `panoptes.utils.rs232.find_serial_port` can be used to look up a serial port from the vendor and product hex ids.  #269
+* ``panoptes.utils.rs232.find_serial_port()`` can be used to look up a serial port from the vendor and product hex ids.  #269
+* ``pnaoptes.utils.config.config.client.get_config()`` changed so ``default`` is the second parameter. #272
 
 0.2.32 - 2020-02-28
 -------------------

--- a/src/panoptes/utils/config/client.py
+++ b/src/panoptes/utils/config/client.py
@@ -17,11 +17,11 @@ def server_is_running():  # pragma: no cover
 
 
 def get_config(key=None,
+               default=None,
                host=None,
                port=None,
                endpoint='get-config',
                parse=True,
-               default=None,
                verbose=False
                ):
     """Get a config item from the config server.
@@ -54,12 +54,17 @@ def get_config(key=None,
 
         >>> # But you can supply a default.
         >>> get_config(key='foobar', default='baz')
-        'baz'
+        baz
 
-        >>> # Can use Quantities as well
+        >>> # key and default are first two parameters.
+        >>> get_config('foobar', 'baz')
+        baz
+
+        >>> # Can use Quantities as well.
         >>> from astropy import units as u
-        >>> get_config(key='foobar', default=42 * u.meter)
+        >>> get_config('foobar', 42 * u.meter)
         <Quantity 42. m>
+
 
     Notes:
         By default all calls to this function will log at the `trace` level because
@@ -70,6 +75,7 @@ def get_config(key=None,
 
     Args:
         key (str): The key to update, see Examples in :func:`get_config` for details.
+        default (str, optional): The config server port, defaults to 6563.
         host (str, optional): The config server host. First checks for PANOPTES_CONFIG_HOST
             env var, defaults to 'localhost'.
         port (str or int, optional): The config server port. First checks for PANOPTES_CONFIG_HOST
@@ -79,7 +85,6 @@ def get_config(key=None,
             for example of usage.
         parse (bool, optional): If response should be parsed by
             :func:`panoptes.utils.serializers.from_json`, default True.
-        default (str, optional): The config server port, defaults to 6563.
         verbose (bool, optional): Determines the output log level, defaults to
             True (i.e. `debug` log level). See notes for details.
     Returns:

--- a/src/panoptes/utils/config/client.py
+++ b/src/panoptes/utils/config/client.py
@@ -54,11 +54,11 @@ def get_config(key=None,
 
         >>> # But you can supply a default.
         >>> get_config(key='foobar', default='baz')
-        baz
+        'baz'
 
         >>> # key and default are first two parameters.
         >>> get_config('foobar', 'baz')
-        baz
+        'baz'
 
         >>> # Can use Quantities as well.
         >>> from astropy import units as u

--- a/src/panoptes/utils/config/client.py
+++ b/src/panoptes/utils/config/client.py
@@ -98,28 +98,29 @@ def get_config(key=None,
     config_entry = default
 
     try:
-        logger.log(log_level, f'Calling get_config on {url=!r} with  {key=!r}')
+        logger.log(log_level, f'Calling get_config on url={url!r} with  key={key!r}')
         response = requests.post(url, json={'key': key, 'verbose': verbose})
         if not response.ok:  # pragma: no cover
-            raise InvalidConfig(f'Config server returned invalid JSON:  {response.content!r}')
+            raise InvalidConfig(
+                f'Config server returned invalid JSON:  response.content={response.content!r}')
     except Exception as e:
         logger.warning(f'Problem with get_config: {e!r}')
     else:
         response_text = response.text.strip()
-        logger.log(log_level, f'Decoded {response_text=!r}')
+        logger.log(log_level, f'Decoded  response_text={response_text!r}')
         if response_text != 'null':
-            logger.log(log_level, f'Received config {key=!r}  {response_text!r}')
+            logger.log(log_level, f'Received config key={key!r}  response_text={response_text!r}')
             if parse:
-                logger.log(log_level, f'Parsing config results:  {response_text!r}')
+                logger.log(log_level, f'Parsing config results:  response_text={response_text!r}')
                 config_entry = from_json(response_text)
             else:
                 config_entry = response_text
 
     if config_entry is None:
-        logger.log(log_level, f'No config entry found, returning  {default=!r}')
+        logger.log(log_level, f'No config entry found, returning  default={default!r}')
         config_entry = default
 
-    logger.log(log_level, f'Config {key=!r}:  {config_entry=!r}')
+    logger.log(log_level, f'Config key={key!r}:  config_entry={config_entry!r}')
     return config_entry
 
 

--- a/src/panoptes/utils/config/client.py
+++ b/src/panoptes/utils/config/client.py
@@ -101,8 +101,7 @@ def get_config(key=None,
         logger.log(log_level, f'Calling get_config on url={url!r} with  key={key!r}')
         response = requests.post(url, json={'key': key, 'verbose': verbose})
         if not response.ok:  # pragma: no cover
-            raise InvalidConfig(
-                f'Config server returned invalid JSON:  response.content={response.content!r}')
+            raise InvalidConfig(f'Config server returned invalid JSON: {response.content!r}')
     except Exception as e:
         logger.warning(f'Problem with get_config: {e!r}')
     else:

--- a/src/panoptes/utils/config/client.py
+++ b/src/panoptes/utils/config/client.py
@@ -22,7 +22,7 @@ def get_config(key=None,
                endpoint='get-config',
                parse=True,
                default=None,
-               verbose=True
+               verbose=False
                ):
     """Get a config item from the config server.
 
@@ -98,28 +98,28 @@ def get_config(key=None,
     config_entry = default
 
     try:
-        logger.log(log_level, f'Calling get_config on url={url!r} with  key={key!r}')
+        logger.log(log_level, f'Calling get_config on {url=!r} with  {key=!r}')
         response = requests.post(url, json={'key': key, 'verbose': verbose})
         if not response.ok:  # pragma: no cover
-            raise InvalidConfig(f'Config server returned invalid JSON:  response.content={response.content!r}')
+            raise InvalidConfig(f'Config server returned invalid JSON:  {response.content!r}')
     except Exception as e:
         logger.warning(f'Problem with get_config: {e!r}')
     else:
         response_text = response.text.strip()
-        logger.log(log_level, f'Decoded  response_text={response_text!r}')
+        logger.log(log_level, f'Decoded {response_text=!r}')
         if response_text != 'null':
-            logger.log(log_level, f'Received config key={key!r}  response_text={response_text!r}')
+            logger.log(log_level, f'Received config {key=!r}  {response_text!r}')
             if parse:
-                logger.log(log_level, f'Parsing config results:  response_text={response_text!r}')
+                logger.log(log_level, f'Parsing config results:  {response_text!r}')
                 config_entry = from_json(response_text)
             else:
                 config_entry = response_text
 
     if config_entry is None:
-        logger.log(log_level, f'No config entry found, returning  default={default!r}')
+        logger.log(log_level, f'No config entry found, returning  {default=!r}')
         config_entry = default
 
-    logger.log(log_level, f'Config key={key!r}:  config_entry={config_entry!r}')
+    logger.log(log_level, f'Config {key=!r}:  {config_entry=!r}')
     return config_entry
 
 
@@ -172,7 +172,7 @@ def set_config(key, new_value, host=None, port=None, parse=True):
     config_entry = None
     try:
         # We use our own serializer so pass as `data` instead of `json`.
-        logger.info(f'Calling set_config on  url={url!r}')
+        logger.debug(f'Calling set_config on  url={url!r}')
         response = requests.post(url,
                                  data=json_str,
                                  headers={'Content-Type': 'application/json'}

--- a/src/panoptes/utils/logging.py
+++ b/src/panoptes/utils/logging.py
@@ -1,1 +1,0 @@
-from loguru import logger


### PR DESCRIPTION
Make the config getter and setter less noisy by default.
Remove old unused logging file.
Make `default` the second parameter for `get_config` to mimic `dict.get`.  Closes #268 