### PR TITLE
SerialDevice docs update

### DIFF
--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -36,7 +36,7 @@ jobs:
           mkdir -p build && chmod -R 777 build
       - name: Test panoptes-utils
         run: |
-          docker run --rm -i -v "${PWD}/build:/app/build" -v "${PWD}/logs:/app/logs" panoptes-utils:testing
+          docker run --rm -i --privileged -v "${PWD}/build:/app/build" -v "${PWD}/logs:/app/logs" panoptes-utils:testing
       - name: Upload coverage report to codecov.io
         uses: codecov/codecov-action@v1
         if: success()

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changed
 ^^^^^^^
 
 * The serial protocol handlers were moved to the ``panoptes.utils.serial.handlers`` namespace. #274
+* Testing Dockerfile has `privileged` permission to get device `loop`. #275
 
 0.2.32 - 2020-03-19
 -------------------

--- a/src/panoptes/utils/serial/device.py
+++ b/src/panoptes/utils/serial/device.py
@@ -235,7 +235,8 @@ class SerialDevice(object):
 
             def handle_line(this, data):
                 try:
-                    data = callback(data)
+                    if callback and callable(callback):
+                        data = callback(data)
                     if data is not None:
                         self.readings.append(data)
                 except Exception as e:

--- a/tests/test_serial_device.py
+++ b/tests/test_serial_device.py
@@ -53,6 +53,6 @@ def test_write_raise_exception(caplog):
     assert len(s0.readings) == 0
     s0.write('not a json message')
     time.sleep(0.5)
-    assert caplog.records[-1].message.startswith('Error with callback')
+    assert 'InvalidDeserialization' in caplog.records[-1].message
     assert caplog.records[-1].levelname == 'WARNING'
     assert s0.readings[0] == 'not a json message'

--- a/tests/test_serial_device.py
+++ b/tests/test_serial_device.py
@@ -54,5 +54,5 @@ def test_write_raise_exception(caplog):
     s0.write('not a json message')
     time.sleep(0.5)
     assert 'InvalidDeserialization' in caplog.records[-1].message
-    assert caplog.records[-1].levelname == 'WARNING'
+    assert caplog.records[-1].levelname == 'ERROR'
     assert s0.readings[0] == 'not a json message'

--- a/tests/test_serial_device.py
+++ b/tests/test_serial_device.py
@@ -55,4 +55,4 @@ def test_write_raise_exception(caplog):
     time.sleep(0.5)
     assert 'InvalidDeserialization' in caplog.records[-1].message
     assert caplog.records[-1].levelname == 'ERROR'
-    assert s0.readings[0] == 'not a json message'
+    assert len(s0.readings) == 0


### PR DESCRIPTION
* Removing unused params from `SerialDevice`.
* Remove the `BaseSerialReader` and move inline to the device to save a few lines of codecov. :)
* Testing Dockerfile has `privileged` permission to get device `loop`.