### PR TITLE
Docker updates - condaforge base

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changed
 * The serial protocol handlers were moved to the ``panoptes.utils.serial.handlers`` namespace. #274
 * Testing Dockerfile has `privileged` permission to get device `loop`. #275
 * Dockerfile: update `conda` in Dockerfile before installing environment; install `panoptes-utils` module in user-editable mode. #277.
+* Dockerfile: use ``condaforge/miniforge3`` as the base, which reduces image size. Push multi-stage builds for better caching.
 
 0.2.32 - 2020-03-19
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Changed
 * The serial protocol handlers were moved to the ``panoptes.utils.serial.handlers`` namespace. #274
 * Testing Dockerfile has `privileged` permission to get device `loop`. #275
 * Dockerfile: update `conda` in Dockerfile before installing environment; install `panoptes-utils` module in user-editable mode. #277.
-* Dockerfile: use ``condaforge/miniforge3`` as the base, which reduces image size. Push multi-stage builds for better caching.
+* Dockerfile: use ``condaforge/miniforge3`` as the base, which reduces image size. Push multi-stage builds for better caching. #278, #279
 
 0.2.32 - 2020-03-19
 -------------------

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG image_url=ubuntu
+ARG image_url=condaforge/miniforge3
 ARG image_tag=latest
 FROM ${image_url}:${image_tag} AS pan-utils-base
 
@@ -18,10 +18,10 @@ ENV USERID $userid
 ENV PATH "/home/${PANUSER}/.local/bin:$PATH"
 
 # Install system dependencies as root user.
-RUN echo "Building from ${image_name}:${image_tag}" && \
+RUN echo "Building from ${image_url}:${image_tag}" && \
     apt-get update && apt-get install --no-install-recommends --yes \
         bzip2 ca-certificates \
-        wget gcc git pkg-config sudo less udev wait-for-it \
+        wget gcc pkg-config sudo less udev wait-for-it \
         dcraw exiftool \
         nano neovim ncdu \
         astrometry.net \
@@ -41,33 +41,21 @@ RUN echo "Building from ${image_name}:${image_tag}" && \
 
 FROM pan-utils-base AS pan-utils-conda
 
-# Change to our app user.
-USER "${USERID}"
+COPY docker/environment.yaml .
+RUN echo "Updating conda." && \
+    conda update -n base conda && \
+    echo "Installing environment" && \
+    conda-env update -n base -f environment.yaml && \
+    conda clean -tipsy && \
+    conda clean -y --force-pkgs-dirs
 
-# Miniconda
-WORKDIR /tmp
-RUN echo "Installing conda via miniforge" && \
-    sudo mkdir -p /conda && \
-    sudo chown -R "${PANUSER}:${PANUSER}" /conda && \
-    # Miniforge
-    wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-$(uname -m).sh" \
-        -O install-miniforge.sh && \
-    /bin/sh install-miniforge.sh -b -f -p /conda && \
-    # Initialize conda for the shells.
-    /conda/bin/conda init bash && \
-    rm install-miniforge.sh
+FROM pan-utils-conda AS pan-utils
 
 ARG app_dir=/panoptes-utils
 ENV APP_DIR $app_dir
 
 WORKDIR "${APP_DIR}"
-COPY docker/environment.yaml .
-RUN echo "Updating conda." && \
-    /conda/bin/conda update -n base conda && \
-    echo "Installing environment" && \
-    /conda/bin/conda-env update -n base -f environment.yaml
-
-FROM pan-utils-conda AS pan-utils
+USER "${USERID}"
 
 ARG pip_install_name="panoptes-utils"
 ARG pip_install_extras=""
@@ -77,8 +65,6 @@ RUN echo "Installing panoptes-utils module with ${pip_install_extras}" && \
     /conda/bin/pip install "${pip_install_name}${pip_install_extras}" && \
     # Cleanup
     /conda/bin/pip cache purge && \
-    /conda/bin/conda clean -tipsy && \
-    /conda/bin/conda clean -y --force-pkgs-dirs && \
     sudo apt-get autoremove --purge --yes && \
     sudo apt-get autoclean --yes && \
     sudo apt-get --yes clean && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,7 +64,7 @@ COPY docker/docker-compose.yaml .
 RUN echo "Installing panoptes-utils module with ${pip_install_extras}" && \
     /conda/bin/pip install "${pip_install_name}${pip_install_extras}" && \
     # Cleanup
-    /conda/bin/pip cache purge && \
+    pip cache purge && \
     sudo apt-get autoremove --purge --yes && \
     sudo apt-get autoclean --yes && \
     sudo apt-get --yes clean && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,6 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 ARG panuser=pocs-user
 ARG userid=1000
-ARG pip_install_extras="[config]"
 
 ENV PANUSER $panuser
 ENV USERID $userid


### PR DESCRIPTION
Uses `condaforge//miniforge3` as the docker image base, which now supports `arm64`.

This should help reduce build times and image size.