### PR TITLE
Fix PanFileDB Format and Docker updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,12 @@ Changed
 * Testing Dockerfile has `privileged` permission to get device `loop`. #275
 * Dockerfile: update `conda` in Dockerfile before installing environment; install `panoptes-utils` module in user-editable mode. #277.
 * Dockerfile: use ``condaforge/miniforge3`` as the base, which reduces image size. Push multi-stage builds for better caching. #278, #279
+* Consistent multi-stage names in Dockerfile; added `jupyter_console`. #280
+
+Fixed
+^^^^^
+
+* Don't nest storage objects for the `PanFileDB`. #280
 
 0.2.32 - 2020-03-19
 -------------------

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG image_url=condaforge/miniforge3
 ARG image_tag=latest
-FROM ${image_url}:${image_tag} AS pan-utils-base
+FROM ${image_url}:${image_tag} AS panoptes-utils-base
 
 LABEL description="Installs the dependencies for panoptes-utils."
 LABEL maintainers="developers@projectpanoptes.org"
@@ -38,7 +38,7 @@ RUN echo "Building from ${image_url}:${image_tag}" && \
     mkdir -p "/home/${panuser}/.ssh" && \
     echo "Host localhost\n\tStrictHostKeyChecking no\n" >> "/home/${panuser}/.ssh/config"
 
-FROM pan-utils-base AS pan-utils-conda
+FROM panoptes-utils-base AS panoptes-utils-conda
 
 COPY docker/environment.yaml .
 RUN echo "Updating conda." && \
@@ -49,7 +49,7 @@ RUN echo "Updating conda." && \
     conda clean -y --force-pkgs-dirs && \
     chown -R "${USERID}:${USERID}" /opt/conda    
 
-FROM pan-utils-conda AS pan-utils
+FROM panoptes-utils-conda AS panoptes-utils
 
 ARG app_dir=/panoptes-utils
 ENV APP_DIR $app_dir

--- a/docker/environment.yaml
+++ b/docker/environment.yaml
@@ -9,6 +9,7 @@ dependencies:
   - colorama
   - gevent
   - loguru
+  - jupyter_console
   - matplotlib-base
   - numpy
   - photutils

--- a/src/panoptes/utils/database/file.py
+++ b/src/panoptes/utils/database/file.py
@@ -37,21 +37,20 @@ class PanFileDB(AbstractPanDB):
 
     def insert_current(self, collection, obj, store_permanently=True):
         obj_id = self._make_id()
-        obj = create_storage_obj(collection, obj, obj_id)
-        current_fn = self._get_file(collection, permanent=False)
         result = obj_id
+        storage_obj = create_storage_obj(collection, obj, obj_id)
+        current_fn = self._get_file(collection, permanent=False)
 
         try:
             # Overwrite current collection file with obj.
-            to_json(obj, filename=current_fn, append=False)
+            to_json(storage_obj, filename=current_fn, append=False)
         except Exception as e:
-            raise error.InvalidSerialization(
-                f"Problem serializing object for insertion: {e} {current_fn} {obj!r}")
+            raise error.InvalidSerialization(f"Problem serializing before insert: {e!r} {obj!r}")
 
-        if not store_permanently:
-            return result
-        else:
-            return self.insert(collection, obj)
+        if store_permanently:
+            result = self.insert(collection, obj)
+
+        return result
 
     def insert(self, collection, obj):
         obj_id = self._make_id()
@@ -62,8 +61,7 @@ class PanFileDB(AbstractPanDB):
             to_json(obj, filename=collection_fn)
             return obj_id
         except Exception as e:
-            raise error.InvalidSerialization(
-                f"Problem inserting object into collection: {e}, {obj!r}")
+            raise error.InvalidSerialization(f"Problem serializing before insert: {e!r} {obj!r}")
 
     def get_current(self, collection):
         current_fn = self._get_file(collection, permanent=False)


### PR DESCRIPTION
* Don't nest storage objects for the `PanFileDB`.
* Consistent multi-stage names in Dockerfile
* Add `jupyter_console` to image (we really need a `slim` version).