### PR TITLE
revamp horizon class

### DIFF
--- a/src/panoptes/utils/horizon.py
+++ b/src/panoptes/utils/horizon.py
@@ -45,7 +45,7 @@ class Obstruction(object):
         # We could sort the azimuth offsets to enforce this automatically, but safer to make user
         # explicitly provide ordered points
         if not (np.diff(self._az_offset) > 0).all():
-            raise ValueError("Azimuths must be in ordered clockwise.")
+            raise ValueError("Azimuths must be ordered clockwise.")
 
     def get_horizon(self, az):
         """ Get the horizon level in degrees at a given azimuth.

--- a/src/panoptes/utils/horizon.py
+++ b/src/panoptes/utils/horizon.py
@@ -114,6 +114,12 @@ class Horizon(object):
         # Add default horizon
         self._default_horizon = get_quantity_value(default_horizon, "deg") * u.deg
 
+        # Calculate horizon at each integer azimuth
+        # This is included for backwards compatibility with POCS
+        self.horizon_line = np.zeros(360, dtype="float")
+        for i, az in enumerate(self.horizon_line):
+            self.horizon_line[i] = self.get_horizon(az).to_value(u.deg)
+
     def get_horizon(self, az):
         """ Get the horizon level in degrees at a given azimuth.
         Args:

--- a/src/panoptes/utils/horizon.py
+++ b/src/panoptes/utils/horizon.py
@@ -19,6 +19,9 @@ class Obstruction(object):
         alt_list = []
         az_list = []
 
+        if len(points_list) < 2:
+            raise ValueError("Need at least two points for obstruction.")
+
         for p in points_list:
             if len(p) != 2:
                 raise ValueError("points_list must be provided as alt/az pairs.")

--- a/src/panoptes/utils/horizon.py
+++ b/src/panoptes/utils/horizon.py
@@ -29,6 +29,9 @@ class Obstruction(object):
             alt = get_quantity_value(p[0], u.deg)
             az = get_quantity_value(p[1], u.deg)
 
+            if az < 0:
+                az += 360
+
             if abs(alt) > 90:
                 raise ValueError("Altitudes must be between ±90 deg.")
 

--- a/tests/test_horizon.py
+++ b/tests/test_horizon.py
@@ -70,6 +70,13 @@ def test_good_negative_az():
     assert isinstance(hp2, Horizon)
 
 
+def test_not_clockwise():
+
+    obstructions = [[[10, 5], [10, 355], [10, 10]]]
+    with pytest.raises(ValueError):
+        Horizon(obstructions=obstructions)
+
+
 def test_get_horizon():
     """ Test get_horizon for normal, negative and overlapping obstructions. """
 

--- a/tests/test_horizon.py
+++ b/tests/test_horizon.py
@@ -73,11 +73,12 @@ def test_good_negative_az():
 def test_get_horizon():
     """ Test get_horizon for normal, negative and overlapping obstructions. """
 
-    obstructions = [[[355, 10], [5, 10]],
-                    [[4, -5], [10, 15]]]
+    obstructions = [[[10, 355], [10, 5]],
+                    [[-5, 4], [15, 10]]]
     h = Horizon(obstructions=obstructions)
 
     assert h.get_horizon(0) == 10 * u.deg
     assert h.get_horizon(20) == h._default_horizon
-    assert h.get_horizon(4) == -5 * u.deg
-    assert h.get_horizon(10) == 15
+    assert h.get_horizon(4) != -5 * u.deg
+    assert h.get_horizon(5.1) < 0 * u.deg
+    assert h.get_horizon(9.9) > 0 * u.deg

--- a/tests/test_horizon.py
+++ b/tests/test_horizon.py
@@ -21,34 +21,29 @@ def test_normal():
 
 
 def test_bad_length_tuple():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         Horizon(obstructions=[
             [[20], [40, 70]]
         ])
 
 
 def test_bad_length_list():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         Horizon(obstructions=[
             [[40, 70]]
         ])
 
 
 def test_bad_string():
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         Horizon(obstructions=[
             [["x", 10], [40, 70]]
         ])
 
 
 def test_too_many_points():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         Horizon(obstructions=[[[120, 60, 300]]])
-
-
-def test_wrong_bool():
-    with pytest.raises(AssertionError):
-        Horizon(obstructions=[[[20, 200], [30, False]]])
 
 
 def test_numpy_ints():
@@ -61,13 +56,6 @@ def test_numpy_ints():
     assert isinstance(Horizon(points), Horizon)
 
 
-def test_negative_alt():
-    with pytest.raises(AssertionError):
-        Horizon(obstructions=[
-            [[10, 20], [-1, 30]]
-        ])
-
-
 def test_good_negative_az():
     hp = Horizon(obstructions=[
         [[50, -10], [45, -20]]
@@ -78,22 +66,3 @@ def test_good_negative_az():
         [[10, -181], [20, -190]]
     ])
     assert isinstance(hp2, Horizon)
-
-
-def test_bad_negative_az():
-    with pytest.raises(AssertionError):
-        Horizon(obstructions=[
-            [[10, -361], [20, -350]]
-        ])
-
-
-def test_sorting():
-    points = [
-        [[10., 10.], [20., 20.]],
-        [[30., 190.], [10., 180.]],
-        [[10., 50.], [30., 60.]],
-    ]
-    hp = Horizon(obstructions=points)
-    assert hp.obstructions == [[(10.0, 10.0), (20.0, 20.0)],
-                               [(10.0, 50.0), (30.0, 60.0)],
-                               [(10.0, 180.0), (30.0, 190.0)]]

--- a/tests/test_horizon.py
+++ b/tests/test_horizon.py
@@ -1,6 +1,8 @@
 import pytest
-import numpy as np
 import random
+
+import numpy as np
+from astropy import units as u
 
 from panoptes.utils.horizon import Horizon
 
@@ -66,3 +68,16 @@ def test_good_negative_az():
         [[10, -181], [20, -190]]
     ])
     assert isinstance(hp2, Horizon)
+
+
+def test_get_horizon():
+    """ Test get_horizon for normal, negative and overlapping obstructions. """
+
+    obstructions = [[[355, 10], [5, 10]],
+                    [[4, -5], [10, 15]]]
+    h = Horizon(obstructions=obstructions)
+
+    assert h.get_horizon(0) == 10 * u.deg
+    assert h.get_horizon(20) == h._default_horizon
+    assert h.get_horizon(4) == -5 * u.deg
+    assert h.get_horizon(10) == 15

--- a/tests/test_horizon.py
+++ b/tests/test_horizon.py
@@ -14,7 +14,7 @@ def test_normal():
     assert isinstance(hp, Horizon)
 
     hp2 = Horizon(obstructions=[
-        [[40, 45], [50, 50], [60, 45]]
+        [[40, 45], [50, 50], [60, 60]]
     ])
     assert isinstance(hp2, Horizon)
 
@@ -60,12 +60,12 @@ def test_numpy_ints():
 
 def test_good_negative_az():
     hp = Horizon(obstructions=[
-        [[50, -10], [45, -20]]
+        [[50, -10], [45, -5]]
     ])
     assert isinstance(hp, Horizon)
 
     hp2 = Horizon(obstructions=[
-        [[10, -181], [20, -190]]
+        [[10, -181], [20, -170]]
     ])
     assert isinstance(hp2, Horizon)
 

--- a/tests/test_horizon.py
+++ b/tests/test_horizon.py
@@ -70,6 +70,26 @@ def test_good_negative_az():
     assert isinstance(hp2, Horizon)
 
 
+def test_bad_alt():
+    obstructions = [[[95, 5], [10, 10]]]
+    with pytest.raises(ValueError):
+        Horizon(obstructions=obstructions)
+
+    obstructions = [[[-95, 5], [10, 10]]]
+    with pytest.raises(ValueError):
+        Horizon(obstructions=obstructions)
+
+
+def test_bad_az():
+    obstructions = [[[50, -370], [10, 10]]]
+    with pytest.raises(ValueError):
+        Horizon(obstructions=obstructions)
+
+    obstructions = [[[50, 370], [10, 10]]]
+    with pytest.raises(ValueError):
+        Horizon(obstructions=obstructions)
+
+
 def test_not_clockwise():
 
     obstructions = [[[10, 5], [10, 355], [10, 10]]]


### PR DESCRIPTION
- Fixes bug in `Horizon` caused by sorting obstruction points in azimuth
- `Obstruction` points lists must be in clockwise ordering
- Maintains backwards compatibility so it doesn't break `POCS`