### PR TITLE
Config server port fix.

### DIFF
--- a/src/panoptes/utils/config/cli.py
+++ b/src/panoptes/utils/config/cli.py
@@ -2,6 +2,7 @@ import time
 
 import click
 from loguru import logger
+
 from panoptes.utils.config import server
 from panoptes.utils.config.client import get_config
 from panoptes.utils.config.client import server_is_running
@@ -48,7 +49,7 @@ def config_server_cli(context, host='localhost', port=6563, verbose=False):
               default=2,
               help='Heartbeat interval, default 2 seconds.')
 @click.pass_context
-def run(context, config_file=None, save_local=True, load_local=False, heartbeat=True):
+def run(context, config_file=None, save_local=True, load_local=False, heartbeat=2):
     """Runs the config server with command line options.
 
     This function is installed as an entry_point for the module, accessible
@@ -72,7 +73,7 @@ def run(context, config_file=None, save_local=True, load_local=False, heartbeat=
               f'Set "config_server.running=False" or Ctrl-c to stop')
 
         # Loop until config told to stop.
-        while server_is_running():
+        while server_is_running(host=host, port=port):
             time.sleep(heartbeat)
 
         server_process.terminate()

--- a/src/panoptes/utils/config/client.py
+++ b/src/panoptes/utils/config/client.py
@@ -2,15 +2,16 @@ import os
 
 import requests
 from loguru import logger
+
 from panoptes.utils.error import InvalidConfig
 from panoptes.utils.serializers import from_json
 from panoptes.utils.serializers import to_json
 
 
-def server_is_running():  # pragma: no cover
+def server_is_running(*args, **kwargs):  # pragma: no cover
     """Thin-wrapper to check server."""
     try:
-        return get_config(endpoint='heartbeat', verbose=False)
+        return get_config(endpoint='heartbeat', verbose=False, *args, **kwargs)
     except Exception as e:
         logger.warning(f'server_is_running error (ignore if just starting server): {e!r}')
         return False

--- a/src/panoptes/utils/config/server.py
+++ b/src/panoptes/utils/config/server.py
@@ -8,10 +8,11 @@ from flask import request
 from flask.json import JSONEncoder
 from gevent.pywsgi import WSGIServer
 from loguru import logger
+from scalpl import Cut
+
 from panoptes.utils.config.helpers import load_config
 from panoptes.utils.config.helpers import save_config
 from panoptes.utils.serializers import serialize_object
-from scalpl import Cut
 
 # Turn off noisy logging for Flask wsgi server.
 logging.getLogger('werkzeug').setLevel(logging.WARNING)
@@ -52,8 +53,7 @@ def config_server(config_file,
     A convenience function to start the config server.
 
     Args:
-        config_file (str or None): The absolute path to the config file to load. Checks for
-            PANOPTES_CONFIG_FILE env var and fails if not provided.
+        config_file (str or None): The absolute path to the config file to load.
         host (str, optional): The config server host. First checks for PANOPTES_CONFIG_HOST
             env var, defaults to 'localhost'.
         port (str or int, optional): The config server port. First checks for PANOPTES_CONFIG_HOST
@@ -71,7 +71,6 @@ def config_server(config_file,
     Returns:
         multiprocessing.Process: The process running the config server.
     """
-    config_file = config_file or os.environ['PANOPTES_CONFIG_FILE']
     logger.info(f'Starting panoptes-config-server with  config_file={config_file!r}')
     config = load_config(config_files=config_file, load_local=load_local)
     logger.success(f'Config server Loaded {len(config)} top-level items')


### PR DESCRIPTION
Allow config server to properly run on different port by fixing the `server_is_running` heartbeat check.

Also removes support for the `PANOPTES_CONFIG_FILE` env var.