### PR TITLE
CR2 to FITS cli

### DIFF
--- a/src/panoptes/utils/cli/image.py
+++ b/src/panoptes/utils/cli/image.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Union
 
 import typer
 
@@ -8,10 +9,20 @@ app = typer.Typer()
 
 
 @app.command('convert-cr2')
-def cr2_to_fits(file_path: Path, remove_cr2: bool = True) -> Path:
+def cr2_to_fits(
+        cr2_fname: Union[str, Path],
+        fits_fname: str = None,
+        overwrite: bool = False,
+        fits_headers: dict = None,
+        remove_cr2: bool = False,
+) -> Path:
     """Convert a CR2 image to a FITS, return the new path name."""
-    print(f'Converting {file_path} to FITS')
-    fits_fn = cr2.cr2_to_fits(file_path, remove_cr2=remove_cr2)
+    print(f'Converting {cr2_fname} to FITS')
+    fits_fn = cr2.cr2_to_fits(cr2_fname,
+                              fits_fname=fits_fname,
+                              overwrite=overwrite,
+                              fits_headers=fits_headers,
+                              remove_cr2=remove_cr2)
     print(f'FITS file available at {fits_fn}')
 
     return Path(fits_fn)

--- a/src/panoptes/utils/cli/image.py
+++ b/src/panoptes/utils/cli/image.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import typer
+
+from panoptes.utils.images import cr2
+
+app = typer.Typer()
+
+
+@app.command('convert-cr2')
+def cr2_to_fits(file_path: Path, remove_cr2: bool = True) -> Path:
+    """Convert a CR2 image to a FITS, return the new path name."""
+    print(f'Converting {file_path} to FITS')
+    fits_fn = cr2.cr2_to_fits(file_path, remove_cr2=remove_cr2)
+    print(f'FITS file available at {fits_fn}')
+
+    return Path(fits_fn)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/panoptes/utils/cli/main.py
+++ b/src/panoptes/utils/cli/main.py
@@ -1,0 +1,11 @@
+import typer
+
+from panoptes.utils.cli import image
+
+app = typer.Typer()
+state = {'verbose': False}
+
+app.add_typer(image.app, name="image", help='Process an image.')
+
+if __name__ == "__main__":
+    app()

--- a/src/panoptes/utils/images/cr2.py
+++ b/src/panoptes/utils/images/cr2.py
@@ -2,25 +2,28 @@ import os
 import shutil
 import subprocess
 from json import loads
+from pathlib import Path
+from typing import Union
 from warnings import warn
 
 import numpy as np
 from astropy.io import fits
 from dateutil.parser import parse as date_parse
 from loguru import logger
+
 from panoptes.utils import error
 from panoptes.utils.images import fits as fits_utils
 
 
 def cr2_to_fits(
-        cr2_fname,
-        fits_fname=None,
-        overwrite=False,
-        headers={},
-        fits_headers={},
-        remove_cr2=False,
-        **kwargs):  # pragma: no cover
-    """Convert a CR2 file to FITS
+        cr2_fname: Union[str, Path],
+        fits_fname: str = None,
+        overwrite: bool = False,
+        headers: dict = None,
+        fits_headers: dict = None,
+        remove_cr2: bool = False,
+        **kwargs) -> str:  # pragma: no cover
+    """Convert a CR2 file to FITS.
 
     This is a convenience function that first converts the CR2 to PGM via ~cr2_to_pgm.
     Also adds keyword headers to the FITS file.
@@ -42,11 +45,20 @@ def cr2_to_fits(
         str: The full path to the generated FITS file.
 
     """
+    if fits_headers is None:
+        fits_headers = {}
+    if headers is None:
+        headers = {}
+
+    # Convert path to just a str.
+    if isinstance(fits_fname, Path):
+        fits_fname = str(Path)
+
     if fits_fname is None:
         fits_fname = cr2_fname.replace('.cr2', '.fits')
 
     if not os.path.exists(fits_fname) or overwrite:
-        logger.debug("Converting CR2 to PGM: {}".format(cr2_fname))
+        logger.debug(f'Converting CR2 to PGM: {cr2_fname}')
 
         # Convert the CR2 to a PGM file then delete PGM
         pgm = read_pgm(cr2_to_pgm(cr2_fname), remove_after=True)
@@ -86,11 +98,11 @@ def cr2_to_fits(
                 pass
 
         try:
-            logger.debug("Saving fits file to: {}".format(fits_fname))
+            logger.debug(f'Saving fits file to: {fits_fname}')
 
             hdu.writeto(fits_fname, output_verify='silentfix', overwrite=overwrite)
         except Exception as e:
-            warn("Problem writing FITS file: {}".format(e))
+            warn(f'Problem writing FITS file: {e}')
         else:
             if remove_cr2:
                 os.unlink(cr2_fname)
@@ -136,20 +148,20 @@ def cr2_to_pgm(
         pgm_fname = cr2_fname.replace('.cr2', '.pgm')
 
     if os.path.exists(pgm_fname) and not overwrite:
-        logger.warning(f"PGM file exists, returning existing file: {pgm_fname}")
+        logger.warning(f'PGM file exists, returning existing file: {pgm_fname}')
     else:
         try:
             # Build the command for this file
-            command = '{} -t 0 -D -4 {}'.format(dcraw, cr2_fname)
+            command = f'{dcraw} -t 0 -D -4 {cr2_fname}'
             cmd_list = command.split()
-            logger.debug("PGM Conversion command: \n {}".format(cmd_list))
+            logger.debug(f'PGM Conversion command: \n {cmd_list}')
 
             # Run the command
             if subprocess.check_call(cmd_list) == 0:
-                logger.debug("PGM Conversion command successful")
+                logger.debug('PGM Conversion command successful')
 
         except subprocess.CalledProcessError as err:
-            raise error.InvalidSystemCommand(msg="File: {} \n err: {}".format(cr2_fname, err))
+            raise error.InvalidSystemCommand(msg=f"File: {cr2_fname} \n err: {err}")
 
     return pgm_fname
 
@@ -169,22 +181,21 @@ def read_exif(fname, exiftool='exiftool'):  # pragma: no cover
         exiftool {str} -- Location of exiftool (default: {'/usr/bin/exiftool'})
 
     Returns:
-        dict -- Dictonary of EXIF information
+        dict -- Dictionary of EXIF information
 
     """
-    assert os.path.exists(fname), warn("File does not exist: {}".format(fname))
+    assert os.path.exists(fname), warn(f"File does not exist: {fname}")
     exif = {}
 
     try:
         # Build the command for this file
-        command = '{} -j {}'.format(exiftool, fname)
+        command = f'{exiftool} -j {fname}'
         cmd_list = command.split()
 
         # Run the command
         exif = loads(subprocess.check_output(cmd_list).decode('utf-8'))
     except subprocess.CalledProcessError as err:
-        raise error.InvalidSystemCommand(
-            msg="File: {} \n err: {}".format(fname, err))
+        raise error.InvalidSystemCommand(msg=f"File: {fname} \n err: {err}")
 
     return exif[0]
 
@@ -219,9 +230,9 @@ def read_pgm(fname, byteorder='>', remove_after=False):  # pragma: no cover
     header_offset = 19
 
     img_type, img_size, img_max_value, _ = buffer[
-        0:header_offset].decode().split('\n')
+                                           0:header_offset].decode().split('\n')
 
-    assert img_type == 'P5', warn("No a PGM file")
+    assert img_type == 'P5', warn("Not a PGM file")
 
     # Get the width and height (as strings)
     width, height = img_size.split(' ')


### PR DESCRIPTION
Adds a cli interface for converting Canon `.CR2` files into `FITS` files.

Should be improved in the future to, e.g. take an optional metadata file that could be merged into the headers.

Also adds types to the `cr2_to_fits` command and also allows it to accept `Path`.

Other f-string cleanup.