### PR TITLE
Fix config server testing

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "src/panoptes/utils/config/server.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -121,7 +121,6 @@ addopts =
     -vv
     -ra
     --test-databases memory
-    --test-solve
 norecursedirs =
     dist
     build

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,13 +117,11 @@ addopts =
     --cov-report xml:build/coverage.xml
     --strict-markers
     --doctest-modules
-    --test-databases memory
     --strict-markers
     -vv
     -ra
-    --ignore=tests/config/test_config_cli.py
-    --ignore=tests/config/test_config_server.py
-    --ignore=src/panoptes/utils/config
+    --test-databases memory
+    --test-solve
 norecursedirs =
     dist
     build

--- a/src/panoptes/utils/config/client.py
+++ b/src/panoptes/utils/config/client.py
@@ -45,7 +45,7 @@ def get_config(key=None,
 
         >>> # With no parsing, the raw string (including quotes) is returned.
         >>> get_config(key='location.horizon', parse=False)
-        '"30.0 deg"'
+        '"30 deg"'
         >>> get_config(key='cameras.devices[1].model')
         'canon_gphoto2'
 

--- a/src/panoptes/utils/config/server.py
+++ b/src/panoptes/utils/config/server.py
@@ -36,7 +36,7 @@ class CustomJSONEncoder(JSONEncoder):
         return serialize_object(obj)
 
 
-app.json_provider_class = CustomJSONEncoder
+app.json_encoder = CustomJSONEncoder
 
 
 def config_server(config_file,

--- a/src/panoptes/utils/config/server.py
+++ b/src/panoptes/utils/config/server.py
@@ -5,38 +5,18 @@ from multiprocessing import Process
 from flask import Flask
 from flask import jsonify
 from flask import request
-from flask.json import JSONEncoder
 from gevent.pywsgi import WSGIServer
 from loguru import logger
 from scalpl import Cut
 
 from panoptes.utils.config.helpers import load_config
 from panoptes.utils.config.helpers import save_config
-from panoptes.utils.serializers import serialize_object
 
 # Turn off noisy logging for Flask wsgi server.
 logging.getLogger('werkzeug').setLevel(logging.WARNING)
 logging.getLogger('gevent').setLevel(logging.WARNING)
 
 app = Flask(__name__)
-
-
-class CustomJSONEncoder(JSONEncoder):
-
-    def default(self, obj):
-        """Custom serialization of each object.
-
-        This method will call :func:`panoptes.utils.serializers.serialize_object` for
-        each object.
-
-        Args:
-            obj (`any`): The object to serialize.
-
-        """
-        return serialize_object(obj)
-
-
-app.json_encoder = CustomJSONEncoder
 
 
 def config_server(config_file,
@@ -72,7 +52,7 @@ def config_server(config_file,
         multiprocessing.Process: The process running the config server.
     """
     logger.info(f'Starting panoptes-config-server with  config_file={config_file!r}')
-    config = load_config(config_files=config_file, load_local=load_local)
+    config = load_config(config_files=config_file, load_local=load_local, parse=False)
     logger.success(f'Config server Loaded {len(config)} top-level items')
 
     # Add an entry to control running of the server.
@@ -317,7 +297,9 @@ def reset_config():
     if params['reset']:
         # Reload the config
         config = load_config(config_files=app.config['config_file'],
-                             load_local=app.config['load_local'])
+                             load_local=app.config['load_local'],
+                             parse=params.get('parse', False)
+                             )
         # Add an entry to control running of the server.
         config['config_server'] = dict(running=True)
         app.config['POCS'] = config


### PR DESCRIPTION
* Config server doesn't parse config as loaded so it doesn't need to serialize it before sending a response. The serialization should happen by the client side get_config.
* Restores the config server testing. Closes #296.
* Explicitly ignores the config server file for coverage even though it should be covered by the threads.