### PR TITLE
Don't silently ignore bad config file

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -96,6 +96,11 @@ def config_path() -> str:
     return os.getenv("PANOPTES_CONFIG_FILE", "tests/testing.yaml")
 
 
+@pytest.fixture(scope="session")
+def bad_config_path() -> str:
+    return os.getenv("PANOPTES_CONFIG_FILE", "tests/testing_bad.yaml")
+
+
 @pytest.fixture(scope="function", params=_all_databases)
 def db_type(request):
     db_list = request.config.option.test_databases

--- a/src/panoptes/utils/config/cli.py
+++ b/src/panoptes/utils/config/cli.py
@@ -73,14 +73,18 @@ def run(context, config_file=None, save_local=True, load_local=False, heartbeat=
     """
     host = context.obj.get("host")
     port = context.obj.get("port")
-    server_process = server.config_server(
-        config_file,
-        host=host,
-        port=port,
-        load_local=load_local,
-        save_local=save_local,
-        auto_start=False,
-    )
+    try:
+        server_process = server.config_server(
+            config_file,
+            host=host,
+            port=port,
+            load_local=load_local,
+            save_local=save_local,
+            auto_start=False,
+        )
+    except Exception as e:
+        logger.error(f"Unable to start config server: {e!r}")
+        return
 
     try:
         print("Starting config server. Ctrl-c to stop")

--- a/src/panoptes/utils/config/helpers.py
+++ b/src/panoptes/utils/config/helpers.py
@@ -11,57 +11,37 @@ from panoptes.utils.utils import listify
 
 
 def load_config(
-    config_files: Path | List | None = None, parse: bool = True, load_local: bool = True
+    config_files: str | Path | List | None = None, parse: bool = True, load_local: bool = True
 ) -> dict:
-    """Load configuration information.
+    """Loads configuration information from one or more YAML files.
 
-    .. note::
+    This function is used by the config server; normal config usage should
+    be via a running config server.
 
-        This function is used by the config server and normal config usage should
-        be via a running config server.
-
-    This function supports loading of a number of different files. If no options
-    are passed to ``config_files`` then the default ``$PANOPTES_CONFIG_FILE``
-    will be loaded.
-
-    ``config_files`` is a list and loaded in order, so the second entry will overwrite
-    any values specified by similarly named keys in the first entry.
-
-    ``config_files`` should be specified by an absolute path, which can exist anywhere
-    on the filesystem.
-
-    Local versions of files can override built-in versions and are automatically loaded if
-    they exist alongside the specified config path. Local files have a ``<>_local.yaml`` name, where
-    ``<>`` is the built-in file.
-
-    Given the following path:
-
-    ::
-
-        /path/to/dir
-        |- my_conf.yaml
-        |- my_conf_local.yaml
-
-    You can do a ``load_config('/path/to/dir/my_conf.yaml')`` and both versions of the file will
-    be loaded, with the values in the local file overriding the non-local. Typically the local
-    file would also be ignored by ``git``, etc.
-
-    For example, the ``panoptes.utils.config.server.config_server`` will always save values to
-    a local version of the file so the default settings can always be recovered if necessary.
-
-    Local files can be ignored (mostly for testing purposes or for recovering default values)
-    with the ``load_local=False`` parameter.
+    If no options are passed to `config_files`, the default `$PANOPTES_CONFIG_FILE`
+    will be loaded. Multiple files can be specified and are loaded in order,
+    with later files overwriting values from earlier ones. Local versions of files
+    (named `<name>_local.yaml`) can override built-in versions if present.
 
     Args:
-        config_files (list, optional): A list of files to load as config,
-            see Notes for details of how to specify files.
-        parse (bool, optional): If the config file should attempt to create
-            objects such as dates, astropy units, etc.
-        load_local (bool, optional): If local files should be used, see
-            Notes for details.
+        config_files (str | Path | List | None, optional): A path or list of paths to config files.
+            If None, uses the default config file. Files are loaded in order.
+        parse (bool, optional): Whether to parse objects such as dates and astropy units.
+            Defaults to True.
+        load_local (bool, optional): Whether to load local override files (ending with `_local.yaml`)
+            if present. Defaults to True.
 
     Returns:
-        dict: A dictionary of config items.
+        dict: Dictionary of configuration items.
+
+    Raises:
+        ruamel.yaml.parser.ParserError: If a YAML file cannot be parsed.
+        IOError: If a config file cannot be read.
+        TypeError: If a config file contains invalid data types.
+
+    Notes:
+        Local files are automatically loaded if they exist alongside the specified config path.
+        Local files can be ignored by setting `load_local=False`.
     """
     config = dict()
 
@@ -69,20 +49,14 @@ def load_config(
     logger.debug(f"Loading config files: config_files={config_files!r}")
     for config_file in config_files:
         config_file = Path(config_file)
-        try:
-            logger.debug(f"Adding config_file={config_file!r} to config dict")
-            _add_to_conf(config, config_file, parse=parse)
-        except Exception as e:  # pragma: no cover
-            logger.warning(f"Problem with config_file={config_file!r}, skipping. {e!r}")
+        logger.debug(f"Adding config_file={config_file!r} to config dict")
+        _add_to_conf(config, config_file, parse=parse)
 
         # Load local version of config
         if load_local:
             local_version = config_file.parent / Path(config_file.stem + "_local.yaml")
             if local_version.exists():
-                try:
-                    _add_to_conf(config, local_version, parse=parse)
-                except Exception as e:  # pragma: no cover
-                    logger.warning(f"Problem with local_version={local_version!r}, skipping: {e!r}")
+                _add_to_conf(config, local_version, parse=parse)
 
     # parse_config_directories currently only corrects directory names.
     if parse:

--- a/src/panoptes/utils/config/server.py
+++ b/src/panoptes/utils/config/server.py
@@ -6,6 +6,7 @@ from sys import platform
 from flask import Flask, jsonify, request
 from gevent.pywsgi import WSGIServer
 from loguru import logger
+from ruamel.yaml.parser import ParserError
 from scalpl import Cut
 
 from panoptes.utils.config.helpers import load_config, save_config
@@ -59,8 +60,13 @@ def config_server(
     Returns:
         multiprocessing.Process: The process running the config server.
     """
-    logger.info(f"Starting panoptes-config-server with  config_file={config_file!r}")
-    config = load_config(config_files=config_file, load_local=load_local, parse=False)
+    logger.info(f"Starting panoptes-config-server with config_file={config_file!r}")
+    try:
+        config = load_config(config_files=config_file, load_local=load_local, parse=False)
+    except ParserError as e:
+        logger.error(f"Problem parsing config file {config_file}: {e!r}")
+        raise e
+
     logger.success(f"Config server Loaded {len(config)} top-level items")
 
     # Add an entry to control running of the server.
@@ -317,11 +323,16 @@ def reset_config():
 
     if params["reset"]:
         # Reload the config
-        config = load_config(
-            config_files=app.config["config_file"],
-            load_local=app.config["load_local"],
-            parse=params.get("parse", False),
-        )
+        try:
+            config = load_config(
+                config_files=app.config["config_file"],
+                load_local=app.config["load_local"],
+                parse=params.get("parse", False),
+            )
+        except ParserError as e:
+            logger.error(f"Problem parsing config file {app.config['config_file']}: {e!r}")
+            return jsonify({"success": False, "msg": f"Problem parsing config file: {e!r}"})
+
         # Add an entry to control running of the server.
         config["config_server"] = dict(running=True)
         app.config["POCS"] = config

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -2,9 +2,9 @@ from pathlib import Path
 
 import pytest
 from astropy import units as u
+from ruamel.yaml.parser import ParserError
 
-from panoptes.utils.config.helpers import load_config
-from panoptes.utils.config.helpers import save_config
+from panoptes.utils.config.helpers import load_config, save_config
 from panoptes.utils.serializers import to_yaml
 
 
@@ -12,6 +12,12 @@ def test_load_config(config_path):
     """Test basic loading"""
     conf = load_config(config_files=config_path)
     assert conf["name"] == "Testing PANOPTES Unit"
+
+
+def test_bad_config(bad_config_path):
+    """Test bad config file"""
+    with pytest.raises(ParserError):
+        load_config(config_files=bad_config_path)
 
 
 def test_load_config_custom_file(tmp_path):

--- a/tests/testing_bad.yaml
+++ b/tests/testing_bad.yaml
@@ -1,0 +1,33 @@
+---
+######################### PANOPTES UNIT ########################################
+# name:   Can be anything you want it to be. This name is displayed in several
+#         places and should be a "personal" name for the unit.
+#
+# pan_id: This is an identification number assigned by the PANOPTES team and is
+#         the official designator for your unit. This id is used to store image
+#         files and communicate with the Google Cloud network.
+#
+#         Leave the pan_id at `PAN000` for testing until you have been assigned
+#         an official id. Update pocs_local.yaml with official name once received.
+################################################################################
+name: Testing PANOPTES Unit
+pan_id: PAN000
+
+location:
+  name: Mauna Loa Observatory
+  latitude: 19.54 deg
+  longitude: -155.58 deg
+  elevation: 3400.0 m
+  horizon: 30 deg # targets must be above this to be considered valid.
+  flat_horizon: -6 deg # Flats when sun between this and focus horizon.
+  focus_horizon: -12 deg # Dark enough to focus on stars.
+  observe_horizon: -18 deg # Sun below this limit to observe.
+  timezone: US/Hawaii
+  gmt_offset: -600 # Offset in minutes from GMT during.
+ directories:
+  base: .
+  images: images
+  data: data
+  resources: POCS/resources/
+  targets: POCS/resources/targets
+  mounts: POCS/resources/mounts


### PR DESCRIPTION
* If the yaml file doesn't parse while loading a config file, give an error rather than skipping.

Fixes #316 