### PR TITLE
Document standard serialization tools in AGENTS and GEMINI files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,23 @@ Serial device communication utilities.
 - Test with simulator/mock devices
 - Consider thread safety
 
+### Serialization Module
+
+**Location:** `src/panoptes/utils/serializers.py`
+
+Utilities for standard data serialization, handling astronomical objects like `astropy.units.Quantity` and `astropy.time.Time`.
+
+**Key Functions:**
+- `to_json(obj)`: Converts Python objects (including dicts with Quantities) to a JSON string. Quantities are serialized as strings (e.g., `"42.0 deg"`).
+- `from_json(msg)`: Converts a JSON string back to Python objects. It automatically reconstructs `Quantity` objects for common units (`deg`, `m`, `s`).
+- `serialize_all_objects(obj)`: Recursively serializes all objects in a collection (dict or list) into JSON-safe primitives. Useful for preparing data for FastAPI responses.
+- `to_yaml` / `from_yaml`: Similar utilities for YAML format.
+
+**When modifying or using:**
+- ALWAYS prefer these utilities for network communication or state persistence.
+- Note that `from_json` automatic reconstruction is limited to specific units; for others, you may need manual conversion using `astropy.units`.
+- `serialize_all_objects` is the idiomatic way to prepare complex objects for transmission over REST/FastAPI.
+
 ## Configuration
 
 **Configuration files:** `tests/testing.yaml` (for testing)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * **Repository Workflow Migration:** Transitioned from a triangular `develop`/`main` workflow to a single-remote model. `main` is now the primary development and release branch. #XXX
 * Updated CI workflows, badges, and internal documentation (`CONTRIBUTING.md`, `AGENTS.md`) to reflect the new workflow.
 * Deleted the legacy `develop` branch and removed it from all CI triggers.
+* Added documentation for standard serialization tools (`to_json`, `from_json`, `serialize_all_objects`) to `AGENTS.md` and `GEMINI.md`.
 
 ## 0.3.1 - 2026-03-18
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -17,6 +17,9 @@ This document provides specific instructions for the Gemini CLI agent. For all g
 - **Validation:** Always run tests using `uv run pytest` after any modification. Note the specific testing markers and plot-blocking doctests mentioned in `AGENTS.md`.
 - **Changelog:** Rigorously follow the `CHANGELOG.md` update requirements specified in the "Making Changes" section of `AGENTS.md`.
 
+### Utility Awareness
+- **Search Before Implementation:** Always check `panoptes.utils` for existing functionality. Specifically, use `panoptes.utils.serializers` for any data transmission or persistence tasks to ensure astronomical types (Quantities, Times) are handled correctly and consistently.
+
 ## Quick Links
 - [AGENTS.md](AGENTS.md) - Full project guidelines.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - Development workflow.


### PR DESCRIPTION
# Description

This PR adds documentation for the standard serialization tools provided by `panoptes-utils` to the `AGENTS.md` and `GEMINI.md` files. 

During a recent refactor in POCS to decouple hardware components into standalone FastAPI services, it was identified that AI agents might not be aware of existing utilities for handling complex astronomical types (like `astropy.units.Quantity` and `astropy.time.Time`) over the network.

## Key Changes

- **AGENTS.md**: Added a "Serialization Module" section detailing `to_json`, `from_json`, and `serialize_all_objects`.
- **GEMINI.md**: Added a "Utility Awareness" section reminding agents to search `panoptes.utils` before implementing custom solutions, specifically for data transmission.

These updates ensure that future AI assistants maintain architectural consistency and leverage established project standards for data handling.