### PR TITLE
feat(telemetry): honour store_permanently in insert_current and post_event

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,9 @@ The telemetry server is the preferred replacement for `PanDB`/`PanFileDB` for al
 **PanDB drop-in compatibility:**
 `TelemetryClient` implements `insert_current`, `insert`, `get_current`, `find`, and `clear_current` so that code written against `PanDB`/`PanFileDB` can migrate by changing only the instantiation line. See `docs/database-to-telemetry.md`.
 
+**Ephemeral (non-persistent) events:**
+Pass `store_permanently=False` to `post_event()` or `insert_current()` to update the in-memory current snapshot without writing to the NDJSON file on disk. This matches PanDB's `store_permanently=False` semantics and is intended for high-frequency transient updates (e.g. rapid status polling) where disk persistence is not needed. The sequence counter still increments, so NDJSON files may contain non-contiguous sequence numbers when ephemeral and permanent events are interleaved.
+
 **Astropy Quantity handling:**
 Data posted via `post_event()` is serialized with `to_json()` before transmission. Data retrieved via `current_event()`, `current()`, or `get_current()` is deserialized with `deserialize_all_objects()` so Quantities round-trip correctly (e.g. `45.0 * u.degree` → stored as `"45.0 deg"` → returned as `Quantity`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,14 @@ panoptes-utils/
 4. Validate changes by checking for errors after editing
 5. Run relevant tests to confirm functionality
 
+**Before Committing or Pushing:**
+- Always run linting and formatting checks before committing or pushing:
+  ```bash
+  uv run ruff check .
+  uv run ruff format --check .
+  ```
+- Fix any errors before pushing. CI will fail on lint errors.
+
 **Commit Messages:**
 - Clear, descriptive commit messages
 - Reference issue numbers when applicable

--- a/docs/database-to-telemetry.md
+++ b/docs/database-to-telemetry.md
@@ -146,7 +146,7 @@ print(record['_id'])   # sequence number as string
 
 | Method | PanDB behaviour | TelemetryClient behaviour |
 |---|---|---|
-| `insert_current(..., store_permanently=False)` | Skips the permanent file, only updates current snapshot | `store_permanently` is accepted but ignored — all events are always written to NDJSON |
+| `insert_current(..., store_permanently=False)` | Skips the permanent file, only updates current snapshot | Skips the NDJSON file write, only updates the in-memory current snapshot — matching PanDB semantics |
 | `find(col, obj_id)` | Returns the matching record | Always returns `None`; parse NDJSON files for historical queries |
 | `clear_current(type)` | Deletes `current_<type>.json` | No-op; the server manages its own in-memory snapshot |
 

--- a/src/panoptes/utils/telemetry/client.py
+++ b/src/panoptes/utils/telemetry/client.py
@@ -144,6 +144,7 @@ class TelemetryClient:
         data: Any,
         make_current: bool = True,
         meta: dict[str, Any] | None = None,
+        store_permanently: bool = True,
     ) -> TelemetryEvent:
         """Post a telemetry event to the current telemetry context.
 
@@ -153,11 +154,18 @@ class TelemetryClient:
         The returned :class:`~panoptes.utils.telemetry.models.TelemetryEvent`
         has its ``data`` field deserialized back to astropy Quantities where
         the unit strings are recognised.
+
+        When ``store_permanently`` is ``False`` the event updates the in-memory
+        current snapshot but is **not** written to the NDJSON file on disk.
+        The sequence counter still increments, so consumers of the NDJSON file
+        may see non-contiguous sequence numbers when ephemeral events are
+        interleaved with permanent ones.
         """
         payload = {
             "type": event_type,
             "data": json.loads(to_json(data)),
             "make_current": make_current,
+            "store_permanently": store_permanently,
             "meta": meta or {},
         }
         return self._to_event(self._request("POST", "/event", json=payload))
@@ -209,20 +217,20 @@ class TelemetryClient:
     ) -> str:
         """PanDB-compatible alias: record an event and mark it current.
 
-        The ``store_permanently`` flag is accepted for API compatibility but
-        has no effect — the telemetry server always appends events to the
-        NDJSON stream and always keeps the in-memory current snapshot.
+        When ``store_permanently`` is ``False`` the event updates the in-memory
+        current snapshot (visible via ``GET /current``) but is **not** written
+        to the NDJSON file on disk — matching the original PanDB semantics for
+        high-frequency ephemeral updates.
 
         Args:
             collection: Event type / collection name (e.g. ``"weather"``).
             obj: Data payload to record.
-            store_permanently: Accepted but ignored; included for PanDB
-                compatibility only.
+            store_permanently: If ``False``, skip the persistent NDJSON write.
 
         Returns:
             The sequence number of the recorded event as a string.
         """
-        response = self.post_event(collection, obj, make_current=True)
+        response = self.post_event(collection, obj, make_current=True, store_permanently=store_permanently)
         return str(response.seq)
 
     def insert(self, collection: str, obj: Any) -> str:

--- a/src/panoptes/utils/telemetry/server.py
+++ b/src/panoptes/utils/telemetry/server.py
@@ -110,6 +110,7 @@ class EventRequest(BaseModel):
     type: str
     data: Any
     make_current: bool = True
+    store_permanently: bool = True
     meta: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -257,10 +258,11 @@ class TelemetryService:
                 "meta": event_meta,
             }
 
-            output_path = self._stream_path(target, now)
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            with output_path.open("a", encoding="utf-8") as output_file:
-                output_file.write(json.dumps(envelope, separators=(",", ":")) + "\n")
+            if request.store_permanently:
+                output_path = self._stream_path(target, now)
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                with output_path.open("a", encoding="utf-8") as output_file:
+                    output_file.write(json.dumps(envelope, separators=(",", ":")) + "\n")
 
             self._seq[target] = envelope["seq"]
 

--- a/tests/test_telemetry_client.py
+++ b/tests/test_telemetry_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 
 from fastapi.testclient import TestClient
@@ -90,7 +91,8 @@ def test_telemetry_client_current_merges_site_and_run_context(tmp_path):
 
 
 def test_pandb_compat_insert_current_returns_seq(tmp_path):
-    app = create_app(TelemetryService(tmp_path / "site"))
+    site_dir = tmp_path / "site"
+    app = create_app(TelemetryService(site_dir))
 
     with TestClient(app) as test_client:
         client = TelemetryClient(base_url="http://testserver", session=test_client)
@@ -100,6 +102,29 @@ def test_pandb_compat_insert_current_returns_seq(tmp_path):
 
         obj_id2 = client.insert_current("weather", {"sky": "cloudy"}, store_permanently=False)
         assert obj_id2 == "2"
+
+        ndjson_files = list(site_dir.glob("*.ndjson"))
+        assert len(ndjson_files) == 1
+        lines = ndjson_files[0].read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["seq"] == 1
+
+
+def test_post_event_store_permanently_false_skips_file_write(tmp_path):
+    site_dir = tmp_path / "site"
+    app = create_app(TelemetryService(site_dir))
+
+    with TestClient(app) as test_client:
+        client = TelemetryClient(base_url="http://testserver", session=test_client)
+
+        event = client.post_event("weather", {"sky": "clear"}, store_permanently=False)
+        assert event.seq == 1
+
+        current = client.current()
+        assert "weather" in current
+
+        ndjson_files = list(site_dir.glob("*.ndjson"))
+        assert ndjson_files == []
 
 
 def test_pandb_compat_insert_returns_seq_and_does_not_update_current(tmp_path):

--- a/tests/test_telemetry_server.py
+++ b/tests/test_telemetry_server.py
@@ -210,7 +210,9 @@ def test_ephemeral_event_skips_file_write(tmp_path):
     site_dir = tmp_path / "site"
     client = TestClient(create_app(TelemetryService(site_dir, now_provider=lambda: fixed_now)))
 
-    response = client.post("/event", json={"type": "weather", "data": {"sky": "clear"}, "store_permanently": False})
+    response = client.post(
+        "/event", json={"type": "weather", "data": {"sky": "clear"}, "store_permanently": False}
+    )
 
     assert response.status_code == 200
     payload = response.json()

--- a/tests/test_telemetry_server.py
+++ b/tests/test_telemetry_server.py
@@ -205,6 +205,47 @@ def test_append_event_does_not_advance_sequence_on_write_failure(tmp_path, monke
     assert third_event["seq"] == 2
 
 
+def test_ephemeral_event_skips_file_write(tmp_path):
+    fixed_now = datetime(2026, 3, 17, 14, 15, tzinfo=UTC)
+    site_dir = tmp_path / "site"
+    client = TestClient(create_app(TelemetryService(site_dir, now_provider=lambda: fixed_now)))
+
+    response = client.post("/event", json={"type": "weather", "data": {"sky": "clear"}, "store_permanently": False})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["seq"] == 1
+
+    current_response = client.get("/current")
+    assert "weather" in current_response.json()["current"]
+
+    ndjson_files = list(site_dir.glob("*.ndjson"))
+    assert ndjson_files == []
+
+
+def test_mixed_permanent_and_ephemeral_events(tmp_path):
+    fixed_now = datetime(2026, 3, 17, 14, 20, tzinfo=UTC)
+    site_dir = tmp_path / "site"
+    client = TestClient(create_app(TelemetryService(site_dir, now_provider=lambda: fixed_now)))
+
+    permanent = client.post("/event", json={"type": "weather", "data": {"sky": "clear"}}).json()
+    ephemeral = client.post(
+        "/event", json={"type": "weather", "data": {"sky": "cloudy"}, "store_permanently": False}
+    ).json()
+
+    assert permanent["seq"] == 1
+    assert ephemeral["seq"] == 2
+
+    current_response = client.get("/current")
+    assert current_response.json()["current"]["weather"] == ephemeral
+
+    output_path = site_dir / "site_20260317.ndjson"
+    assert output_path.exists()
+    records = _read_ndjson(output_path)
+    assert len(records) == 1
+    assert records[0]["seq"] == 1
+
+
 def test_site_rotation_uses_previous_date_before_noon():
     before_noon = datetime(2026, 3, 17, 11, 59, tzinfo=timezone(timedelta(hours=-7)))
 


### PR DESCRIPTION
## Summary

Implements proper semantics for the `store_permanently` flag in the telemetry layer, matching the original PanDB behaviour.

### Changes

**Server (`telemetry/server.py`)**
- Added `store_permanently: bool = True` to `EventRequest`
- Gate the NDJSON file write behind the flag — ephemeral events still increment the sequence counter and update the in-memory current snapshot, but are not persisted to disk

**Client (`telemetry/client.py`)**
- Added `store_permanently` parameter to `post_event()`
- Threads the flag through `insert_current()` (PanDB-compatible alias)
- Updated docstrings to document non-contiguous sequence numbers when ephemeral and permanent events are interleaved

**Docs (`docs/database-to-telemetry.md`)**
- Updated the compatibility table to reflect the new semantics (was: "ignored"; now: "skips NDJSON write")

**Tests**
- `test_telemetry_server.py`: `test_ephemeral_event_skips_file_write`, `test_mixed_permanent_and_ephemeral_events`
- `test_telemetry_client.py`: `test_post_event_store_permanently_false_skips_file_write`, extended `test_pandb_compat_insert_current_returns_seq` to assert only the permanent event appears in the NDJSON file

### Notes

- `test_cli_server` (in `tests/config/test_config_cli.py`) has a pre-existing `Fatal Python error: Aborted` on macOS due to `multiprocessing.Process` + `CliRunner` — this is unrelated to these changes and will be addressed separately.
