### PR TITLE
Add post_event_hooks to TelemetryService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ MANIFEST
 notebooks/
 site/
 plans/
-telemetry/
+/telemetry/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,18 @@ panoptes-utils/
 @pytest.mark.slow             # Tests that take longer to run
 ```
 
-**Interactive image doctests:**
+**⚠️ Do NOT run tests by file path alone:**
+- `pyproject.toml` sets `testpaths = ["tests", "src"]`, so `uv run pytest tests/test_foo.py` still
+  collects **all** tests (including `src/` doctests and other test files). Some of those tests
+  (e.g. `test_cli_server`) can hang indefinitely.
+- **Always use `-k` to restrict test runs to a specific area**, e.g.:
+  ```bash
+  uv run pytest -k "telemetry"      # only telemetry-related tests
+  uv run pytest -k "config"         # only config-related tests
+  uv run pytest -k "not cli_server" # skip the hanging CLI server test
+  ```
+
+
 - `src/panoptes/utils/images/plot.py` and `src/panoptes/utils/images/misc.py` contain doctest examples that call `fig.show()` / `plt.show()`.
 - These can open blocking plot windows during `uv run pytest` because doctests are enabled for `src/`.
 - Unless you are actively working on those plotting/doc examples, prefer skipping them during local validation, e.g.:

--- a/src/panoptes/utils/telemetry/server.py
+++ b/src/panoptes/utils/telemetry/server.py
@@ -8,12 +8,13 @@ import logging
 import os
 import sys
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, time, timedelta
 from multiprocessing import Process
 from pathlib import Path
 from platform import system
-from threading import Lock, Thread
+from threading import Lock
 from typing import Any, Literal
 
 import uvicorn
@@ -130,11 +131,14 @@ class TelemetryService:
             now_provider: Callable returning the current local datetime. Defaults to
                 ``datetime.now().astimezone()``.
             post_event_hooks: Optional list of callables invoked after every
-                ``append_event`` call.  Each hook receives the public event envelope
-                (``dict``) and the original ``EventRequest`` as positional arguments.
-                Hooks are executed in separate daemon threads so they are
-                **non-blocking**.  Any exception raised by a hook is caught and
-                logged as a warning so it can never interrupt the server.
+                ``append_event`` call.  Each hook receives the full event envelope
+                (``dict``, including the ``stream`` routing field) and a deep copy of
+                the original ``EventRequest`` as positional arguments, so mutations
+                inside one hook cannot affect other hooks or the server's return value.
+                Hooks are dispatched via a bounded ``ThreadPoolExecutor`` so they are
+                **non-blocking** and concurrent hook count is always capped.  Any
+                exception raised by a hook is caught and logged as a warning — it can
+                never interrupt the server.
         """
 
         self.site_dir = Path(site_dir).expanduser()
@@ -153,6 +157,7 @@ class TelemetryService:
         self._post_event_hooks: list[Callable[[dict[str, Any], EventRequest], None]] = list(
             post_event_hooks or []
         )
+        self._hook_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="telemetry-hook")
 
     @property
     def run_active(self) -> bool:
@@ -294,7 +299,9 @@ class TelemetryService:
             result = self._public_event(envelope)
 
         for hook in self._post_event_hooks:
-            Thread(target=self._fire_hook, args=(hook, result, request), daemon=True).start()
+            self._hook_executor.submit(
+                self._fire_hook, hook, copy.deepcopy(envelope), request.model_copy(deep=True)
+            )
 
         return result
 
@@ -304,7 +311,11 @@ class TelemetryService:
         envelope: dict[str, Any],
         request: EventRequest,
     ) -> None:
-        """Invoke a single post-event hook, logging any exception as a warning."""
+        """Invoke a single post-event hook, logging any exception as a warning.
+
+        Both ``envelope`` and ``request`` are per-hook deep copies so mutations
+        inside a hook cannot affect other hooks or the server's return value.
+        """
         try:
             hook(envelope, request)
         except Exception as exc:

--- a/src/panoptes/utils/telemetry/server.py
+++ b/src/panoptes/utils/telemetry/server.py
@@ -13,7 +13,7 @@ from datetime import UTC, datetime, time, timedelta
 from multiprocessing import Process
 from pathlib import Path
 from platform import system
-from threading import Lock
+from threading import Lock, Thread
 from typing import Any, Literal
 
 import uvicorn
@@ -121,6 +121,7 @@ class TelemetryService:
         self,
         site_dir: str | Path,
         now_provider: Callable[[], datetime] | None = None,
+        post_event_hooks: list[Callable[[dict[str, Any], EventRequest], None]] | None = None,
     ) -> None:
         """Create a telemetry service.
 
@@ -128,6 +129,12 @@ class TelemetryService:
             site_dir: Base directory for rotated site stream NDJSON files.
             now_provider: Callable returning the current local datetime. Defaults to
                 ``datetime.now().astimezone()``.
+            post_event_hooks: Optional list of callables invoked after every
+                ``append_event`` call.  Each hook receives the public event envelope
+                (``dict``) and the original ``EventRequest`` as positional arguments.
+                Hooks are executed in separate daemon threads so they are
+                **non-blocking**.  Any exception raised by a hook is caught and
+                logged as a warning so it can never interrupt the server.
         """
 
         self.site_dir = Path(site_dir).expanduser()
@@ -143,6 +150,9 @@ class TelemetryService:
             "run": 0,
         }
         self._active_run: ActiveRun | None = None
+        self._post_event_hooks: list[Callable[[dict[str, Any], EventRequest], None]] = list(
+            post_event_hooks or []
+        )
 
     @property
     def run_active(self) -> bool:
@@ -236,6 +246,10 @@ class TelemetryService:
     def append_event(self, request: EventRequest) -> dict[str, Any]:
         """Append an event to the current telemetry target and update the current view.
 
+        After the event is written and the internal lock is released, any registered
+        ``post_event_hooks`` are invoked in separate daemon threads.  Hook failures
+        are caught and logged as warnings and never affect the return value.
+
         Args:
             request: Event request payload.
 
@@ -277,7 +291,28 @@ class TelemetryService:
                 run_id=event_meta.get("run_id"),
             )
 
-            return self._public_event(envelope)
+            result = self._public_event(envelope)
+
+        for hook in self._post_event_hooks:
+            Thread(target=self._fire_hook, args=(hook, result, request), daemon=True).start()
+
+        return result
+
+    @staticmethod
+    def _fire_hook(
+        hook: Callable[[dict[str, Any], EventRequest], None],
+        envelope: dict[str, Any],
+        request: EventRequest,
+    ) -> None:
+        """Invoke a single post-event hook, logging any exception as a warning."""
+        try:
+            hook(envelope, request)
+        except Exception as exc:
+            logger.warning(
+                "Post-event hook {hook!r} raised an exception and was skipped: {exc!r}",
+                hook=hook,
+                exc=exc,
+            )
 
     def current_snapshot(self) -> dict[str, Any]:
         """Return the materialized current view for the public telemetry feed."""

--- a/tests/test_telemetry_server.py
+++ b/tests/test_telemetry_server.py
@@ -279,11 +279,11 @@ def test_post_event_hook_is_called_with_envelope_and_request(tmp_path):
         done.set()
 
     service = TelemetryService(tmp_path / "site", post_event_hooks=[my_hook])
-    result = service.append_event(EventRequest(type="weather", data={"sky": "clear"}))
+    service.append_event(EventRequest(type="weather", data={"sky": "clear"}))
 
     assert done.wait(timeout=1.0), "hook was not called within 1 second"
-    assert received["envelope"] == result
     assert received["envelope"]["type"] == "weather"
+    assert received["envelope"]["stream"] in ("site", "run")
     assert received["request"].type == "weather"
     assert received["request"].store_permanently is True
 
@@ -304,13 +304,16 @@ def test_post_event_hook_receives_store_permanently_flag(tmp_path):
 
 
 def test_post_event_hook_exception_is_non_fatal(tmp_path):
+    hook_ran = threading.Event()
+
     def bad_hook(envelope, request):
+        hook_ran.set()
         raise RuntimeError("boom")
 
     service = TelemetryService(tmp_path / "site", post_event_hooks=[bad_hook])
     result = service.append_event(EventRequest(type="weather", data={"sky": "clear"}))
 
-    time.sleep(0.05)  # give the daemon thread a moment to run
+    assert hook_ran.wait(timeout=1.0), "hook was not called within 1 second"
     assert result["seq"] == 1  # server still returned normally
 
 
@@ -348,13 +351,10 @@ def test_post_event_hook_does_not_block_server_response(tmp_path):
         slow_hook_finished.set()
 
     service = TelemetryService(tmp_path / "site", post_event_hooks=[slow_hook])
-
-    start = time.monotonic()
     result = service.append_event(EventRequest(type="weather", data={}))
-    elapsed = time.monotonic() - start
 
-    # append_event must return before the slow hook finishes
-    assert elapsed < 0.1, f"append_event blocked for {elapsed:.3f}s — hook was not non-blocking"
+    # The hook sleeps for 0.2 s; if append_event was synchronous it would have waited.
+    assert not slow_hook_finished.is_set(), "hook finished before append_event returned — was it blocking?"
     assert result["seq"] == 1
-    slow_hook_started.wait(timeout=1.0)
-    slow_hook_finished.wait(timeout=1.0)
+    assert slow_hook_started.wait(timeout=1.0), "hook thread never started"
+    assert slow_hook_finished.wait(timeout=1.0), "hook thread never completed"

--- a/tests/test_telemetry_server.py
+++ b/tests/test_telemetry_server.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 
@@ -260,3 +262,99 @@ def test_site_rotation_uses_current_date_at_or_after_noon():
 
     assert get_site_day_key(at_noon) == "20260317"
     assert get_site_day_key(after_noon) == "20260317"
+
+
+# ---------------------------------------------------------------------------
+# Post-event hook tests
+# ---------------------------------------------------------------------------
+
+
+def test_post_event_hook_is_called_with_envelope_and_request(tmp_path):
+    received = {}
+    done = threading.Event()
+
+    def my_hook(envelope, request):
+        received["envelope"] = envelope
+        received["request"] = request
+        done.set()
+
+    service = TelemetryService(tmp_path / "site", post_event_hooks=[my_hook])
+    result = service.append_event(EventRequest(type="weather", data={"sky": "clear"}))
+
+    assert done.wait(timeout=1.0), "hook was not called within 1 second"
+    assert received["envelope"] == result
+    assert received["envelope"]["type"] == "weather"
+    assert received["request"].type == "weather"
+    assert received["request"].store_permanently is True
+
+
+def test_post_event_hook_receives_store_permanently_flag(tmp_path):
+    received = []
+    done = threading.Event()
+
+    def my_hook(envelope, request):
+        received.append(request.store_permanently)
+        done.set()
+
+    service = TelemetryService(tmp_path / "site", post_event_hooks=[my_hook])
+    service.append_event(EventRequest(type="status", data={}, store_permanently=False))
+
+    assert done.wait(timeout=1.0), "hook was not called within 1 second"
+    assert received == [False]
+
+
+def test_post_event_hook_exception_is_non_fatal(tmp_path):
+    def bad_hook(envelope, request):
+        raise RuntimeError("boom")
+
+    service = TelemetryService(tmp_path / "site", post_event_hooks=[bad_hook])
+    result = service.append_event(EventRequest(type="weather", data={"sky": "clear"}))
+
+    time.sleep(0.05)  # give the daemon thread a moment to run
+    assert result["seq"] == 1  # server still returned normally
+
+
+def test_multiple_post_event_hooks_all_fire(tmp_path):
+    calls = []
+    all_done = threading.Barrier(3)  # main thread + 2 hooks
+
+    def hook_a(envelope, request):
+        calls.append("a")
+        all_done.wait(timeout=1.0)
+
+    def hook_b(envelope, request):
+        calls.append("b")
+        all_done.wait(timeout=1.0)
+
+    service = TelemetryService(tmp_path / "site", post_event_hooks=[hook_a, hook_b])
+    service.append_event(EventRequest(type="weather", data={}))
+    all_done.wait(timeout=1.0)
+
+    assert sorted(calls) == ["a", "b"]
+
+
+def test_no_hooks_by_default(tmp_path):
+    service = TelemetryService(tmp_path / "site")
+    assert service._post_event_hooks == []
+
+
+def test_post_event_hook_does_not_block_server_response(tmp_path):
+    slow_hook_started = threading.Event()
+    slow_hook_finished = threading.Event()
+
+    def slow_hook(envelope, request):
+        slow_hook_started.set()
+        time.sleep(0.2)
+        slow_hook_finished.set()
+
+    service = TelemetryService(tmp_path / "site", post_event_hooks=[slow_hook])
+
+    start = time.monotonic()
+    result = service.append_event(EventRequest(type="weather", data={}))
+    elapsed = time.monotonic() - start
+
+    # append_event must return before the slow hook finishes
+    assert elapsed < 0.1, f"append_event blocked for {elapsed:.3f}s — hook was not non-blocking"
+    assert result["seq"] == 1
+    slow_hook_started.wait(timeout=1.0)
+    slow_hook_finished.wait(timeout=1.0)


### PR DESCRIPTION
## Summary

Adds a `post_event_hooks` parameter to `TelemetryService` so callers can register callbacks that fire after every `append_event` call — without coupling the library to any specific cloud SDK or storage backend.

## Motivation

POCS needs to mirror telemetry events to Firestore as part of its migration away from the old `PanDB` JSON store. Rather than subclassing `TelemetryService` in POCS or adding Firestore-specific code here in `panoptes-utils`, this hook mechanism lets POCS simply pass a callback:

```python
app = create_app(
    TelemetryService(site_dir="telemetry", post_event_hooks=[upload_to_firestore])
)
```

## Design

- **Non-blocking**: each hook is invoked in a `daemon=True` thread, so it never holds the internal lock or delays the HTTP response.
- **Non-fatal**: exceptions inside a hook are caught and logged as `WARNING`s — a misbehaving hook (e.g. Firestore unavailable) cannot crash or stall the telemetry server.
- **Lock-safe**: hooks fire *after* the lock is released, so disk writes are already complete when the callback runs.
- **Filterable**: the hook receives both the raw `envelope` dict and the original `EventRequest`, so callers can inspect `request.store_permanently` to skip ephemeral events.

## Changes

- `src/panoptes/utils/telemetry/server.py`: add `post_event_hooks` param, `_post_event_hooks` list, `_fire_hook` static method; refactor `append_event` to capture result before exiting lock, then fire hooks.
- `tests/test_telemetry_server.py`: 6 new tests covering hook invocation, `store_permanently` visibility, exception safety, multiple hooks, default empty list, and non-blocking timing.
- `.gitignore`: anchor `telemetry/` to the repo root so it no longer shadows the `src/panoptes/utils/telemetry/` source package.

## Related

- POCS migration PR: panoptes/POCS#1445