### PR TITLE
Release v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.3.6 - 2026-05-21
+
+### Added
+
+* Added `post_event_hooks` parameter to `TelemetryService`, allowing callers to register callbacks that fire after every `append_event` call. Hooks run via a bounded `ThreadPoolExecutor` (non-blocking), receive deep copies of the envelope and request (mutation-safe), and have exceptions caught and logged as warnings (non-fatal). #358
+
 ## 0.3.5 - 2026-05-21
 
 ### Added


### PR DESCRIPTION
Changelog update for v0.3.6 release.

## Changes in this release

- Added `post_event_hooks` to `TelemetryService` — non-blocking, non-fatal callbacks fired after every `append_event` (PR #358)

## Release checklist
- [x] CHANGELOG updated
- [x] CI passing on `main`
- [ ] PR merged → tag `v0.3.6` on `main`