### PR TITLE
Fix telemetry timestamps to respect POCSTIME in subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [Unreleased]
+
+### Fixed
+
+* Telemetry client now generates timestamps using `current_time()` (respecting `$POCSTIME`) and sends them to the server as part of each event request. The server uses the client-supplied timestamp when present, falling back to its own clock otherwise. This fixes age-calculation errors in POCS tests where `$POCSTIME` is changed mid-test but the telemetry subprocess cannot see those changes.
+
 ## 0.3.6 - 2026-05-21
 
 ### Added

--- a/src/panoptes/utils/telemetry/client.py
+++ b/src/panoptes/utils/telemetry/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import UTC
 from typing import Any
 
 import requests
@@ -11,6 +12,13 @@ from loguru import logger
 
 from panoptes.utils.serializers import deserialize_all_objects, to_json
 from panoptes.utils.telemetry.models import TelemetryEvent
+from panoptes.utils.time import current_time
+
+
+def _client_utc_iso_z() -> str:
+    """Return a UTC ISO-8601 timestamp using ``current_time()`` so that ``$POCSTIME`` is respected."""
+    ts = current_time().to_datetime(UTC).astimezone(UTC)
+    return ts.isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
 class TelemetryClientError(RuntimeError):
@@ -167,6 +175,7 @@ class TelemetryClient:
             "make_current": make_current,
             "store_permanently": store_permanently,
             "meta": meta or {},
+            "ts": _client_utc_iso_z(),
         }
         return self._to_event(self._request("POST", "/event", json=payload))
 

--- a/src/panoptes/utils/telemetry/server.py
+++ b/src/panoptes/utils/telemetry/server.py
@@ -117,6 +117,15 @@ class EventRequest(BaseModel):
     make_current: bool = True
     store_permanently: bool = True
     meta: dict[str, Any] = Field(default_factory=dict)
+    ts: str | None = Field(
+        default=None,
+        description=(
+            "Optional client-supplied UTC timestamp (ISO-8601 with trailing 'Z'). "
+            "When provided the server uses this value instead of generating its own, "
+            "ensuring that ``$POCSTIME`` overrides made in the calling process "
+            "(e.g. during tests) are reflected in the stored event."
+        ),
+    )
 
 
 class TelemetryService:
@@ -274,7 +283,7 @@ class TelemetryService:
                 event_meta["run_id"] = self._active_run.run_id
             envelope = {
                 "seq": self._seq[target] + 1,
-                "ts": utc_iso_z(now),
+                "ts": request.ts if request.ts is not None else utc_iso_z(now),
                 "stream": target,
                 "type": request.type,
                 "data": request.data,

--- a/src/panoptes/utils/telemetry/server.py
+++ b/src/panoptes/utils/telemetry/server.py
@@ -23,6 +23,7 @@ from loguru import logger
 from pydantic import BaseModel, Field
 
 from panoptes.utils import __version__
+from panoptes.utils.time import current_time
 
 if system() == "Darwin":
     import multiprocessing
@@ -41,9 +42,12 @@ StorageTarget = Literal["site", "run"]
 
 
 def utc_iso_z(now: datetime | None = None) -> str:
-    """Return a UTC ISO-8601 timestamp with a trailing ``Z``."""
+    """Return a UTC ISO-8601 timestamp with a trailing ``Z``.
 
-    current = now or datetime.now(UTC)
+    Uses ``current_time()`` by default so that ``$POCSTIME`` is respected
+    during testing.
+    """
+    current = now or current_time().to_datetime(UTC)
     return current.astimezone(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
@@ -143,7 +147,7 @@ class TelemetryService:
 
         self.site_dir = Path(site_dir).expanduser()
         self.site_dir.mkdir(parents=True, exist_ok=True)
-        self._now_provider = now_provider or (lambda: datetime.now().astimezone())
+        self._now_provider = now_provider or (lambda: current_time().to_datetime(UTC).astimezone())
         self._lock = Lock()
         self._current: dict[StorageTarget, dict[str, dict[str, Any]]] = {
             "site": {},


### PR DESCRIPTION
## Problem

The telemetry server runs in a subprocess and calls `current_time()` there to stamp events. When POCS tests change `$POCSTIME` mid-test, the subprocess can't see that change — so `record["date"]` (`ts` field) is always real wall-clock time while the test's `current_time()` returns fake 2020 time, breaking any age calculation.

## Fix

**`telemetry/client.py`** — `post_event` now generates the timestamp client-side via a new `_client_utc_iso_z()` helper that calls `current_time()` in the caller's process (where `$POCSTIME` is visible) and includes it as a `ts` field in every event payload.

**`telemetry/server.py`** — `EventRequest` gains an optional `ts: str | None` field. `append_event` uses `request.ts` when provided, falling back to its own `_now_provider()` otherwise.

This keeps the timestamp generation in the calling process (correct `$POCSTIME`), with the server simply trusting whatever the client sends.