### PR TITLE
feat: deprecate _local.yaml, add default config path and config init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 * Added `ConfigWatcher` in `panoptes.utils.config.watcher` — watches a YAML config file with `watchdog` and fires per-key callbacks when values change. Supports context manager usage.
 * `load_config()` now accepts an optional `model=` parameter; when provided, the loaded dict is validated and returned as a model instance instead of a raw dict.
 * Added `pydantic` and `watchdog` to core dependencies.
+* `load_config(config_files=None)` now resolves the config file from `$PANOPTES_CONFIG_FILE` then `~/.panoptes/config.yaml`, with a warning if neither exists.
+* `save_config(save_path=None, ...)` defaults to `$PANOPTES_CONFIG_FILE` or `~/.panoptes/config.yaml`.
+* Added `panoptes-utils config init` CLI command to create a starter `~/.panoptes/config.yaml` from the built-in template.
+* Added `DEFAULT_CONFIG_PATH` constant (`~/.panoptes/config.yaml`) exported from `panoptes.utils.config`.
+
+### Deprecated
+
+* Auto-loading of `<name>_local.yaml` companion files in `load_config()` is deprecated. Consolidate overrides into `~/.panoptes/config.yaml` and set `$PANOPTES_CONFIG_FILE`.
+* Saving to a path ending in `_local.yaml` via `save_config()` is deprecated for the same reason.
 
 ## 0.3.7 - 2026-05-21
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -10,20 +10,67 @@ typed Pydantic models and a file watcher.  For the legacy HTTP config server, se
 
 ---
 
+## Getting started
+
+Create a starter config file with:
+
+```bash
+panoptes-utils config init
+```
+
+This writes `~/.panoptes/config.yaml` from the built-in template.  Edit it to match
+your hardware and location, then point the software to it:
+
+```bash
+export PANOPTES_CONFIG_FILE=~/.panoptes/config.yaml
+```
+
+To write to a different location, use `--output`:
+
+```bash
+panoptes-utils config init --output /path/to/my_unit.yaml
+```
+
+---
+
 ## Loading config
 
-`load_config` reads one or more YAML files and returns a plain dict:
+`load_config` reads one or more YAML files and returns a plain dict.  When called
+with no arguments it resolves the config file automatically:
+
+1. `$PANOPTES_CONFIG_FILE` environment variable (if set)
+2. `~/.panoptes/config.yaml`
+3. Empty dict with a warning if neither exists
 
 ```python
 from panoptes.utils.config import load_config
 
-config = load_config("path/to/config.yaml")
+# Uses $PANOPTES_CONFIG_FILE or ~/.panoptes/config.yaml automatically
+config = load_config()
 print(config["location"]["latitude"])  # <Quantity 19.54 deg>
+
+# Or supply an explicit path
+config = load_config("path/to/config.yaml")
 ```
 
 Multiple files are merged in order, with later files overriding earlier ones.
-A `*_local.yaml` companion is automatically loaded when present (pass
-`load_local=False` to skip this).
+
+> **Deprecated:** The automatic loading of `<name>_local.yaml` companion files
+> (`load_local=True`) is deprecated.  Consolidate all overrides into your
+> single user config file instead.
+
+---
+
+## Saving config
+
+`save_config` writes a config dict to a YAML file.  When called with no path
+it writes to `$PANOPTES_CONFIG_FILE` or `~/.panoptes/config.yaml`:
+
+```python
+from panoptes.utils.config import save_config
+
+save_config(config={"name": "My Unit"})
+```
 
 ---
 

--- a/src/panoptes/utils/cli/config.py
+++ b/src/panoptes/utils/cli/config.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import shutil
 import time
 from importlib.resources import files
 from pathlib import Path
@@ -23,13 +22,40 @@ def config_init(
         None,
         help="Destination path for the config file. Defaults to ~/.panoptes/config.yaml.",
     ),
+    merge_from: Path = typer.Option(
+        None,
+        "--from",
+        help=(
+            "Path to an existing config or _local.yaml file whose values are merged "
+            "on top of the template. If not given, any *_local.yaml files in the "
+            "current directory are detected automatically."
+        ),
+    ),
     force: bool = typer.Option(False, "--force", "-f", help="Overwrite an existing config file."),
 ) -> None:
     """Create a starter config file at ~/.panoptes/config.yaml.
 
-    Copies the built-in default config template to the destination path.
-    Edit the resulting file to match your hardware and location.
+    Starts from the built-in default template and optionally merges in values
+    from an existing config or _local.yaml override file, so your current
+    settings are preserved.
+
+    Examples::
+
+        # Plain init — write the template
+        panoptes-utils config init
+
+        # Merge an existing override file
+        panoptes-utils config init --from pocs_local.yaml
+
+        # Auto-detect *_local.yaml in the current directory and merge
+        panoptes-utils config init
+
+        # Write to a custom path
+        panoptes-utils config init --output /etc/panoptes/config.yaml
     """
+    from panoptes.utils.config import deep_merge
+    from panoptes.utils.config.helpers import _add_to_conf
+
     dest = Path(output) if output else DEFAULT_CONFIG_PATH
 
     if dest.exists() and not force:
@@ -39,9 +65,48 @@ def config_init(
         )
         raise typer.Exit(code=1)
 
-    template = files("panoptes.utils.config").joinpath("default_config.yaml")
+    # Load template as the base.
+    template_path = files("panoptes.utils.config").joinpath("default_config.yaml")
+    base_config: dict = {}
+    _add_to_conf(base_config, Path(str(template_path)), parse=False)
+
+    # Resolve the override source.
+    override_path: Path | None = None
+    if merge_from:
+        override_path = Path(merge_from)
+        if not override_path.exists():
+            print(f"[red]Override file not found:[/red] {override_path}")
+            raise typer.Exit(code=1)
+    else:
+        # Auto-detect *_local.yaml in the current directory.
+        candidates = sorted(Path.cwd().glob("*_local.yaml"))
+        if len(candidates) == 1:
+            override_path = candidates[0]
+            print(f"[dim]Auto-detected override file:[/dim] {override_path}")
+        elif len(candidates) > 1:
+            names = ", ".join(str(p.name) for p in candidates)
+            print(
+                f"[yellow]Multiple _local.yaml files found ({names}).[/yellow]\n"
+                f"Use [bold]--from <path>[/bold] to specify which one to merge."
+            )
+            raise typer.Exit(code=1)
+
+    # Merge overrides on top of the template.
+    final_config = base_config
+    if override_path:
+        overrides: dict = {}
+        _add_to_conf(overrides, override_path, parse=False)
+        final_config = deep_merge(base_config, overrides)
+        merged_keys = sorted(overrides.keys())
+        print(f"[dim]Merged keys from {override_path.name}:[/dim] {', '.join(merged_keys)}")
+
+    # Write the result.
     dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy(str(template), dest)
+    from panoptes.utils.serializers import to_yaml
+
+    with dest.open("w") as fh:
+        to_yaml(final_config, stream=fh)
+
     print(f"[green]Created config file:[/green] {dest}")
     print("Edit it to match your hardware and location, then set:")
     print(f"  [bold]export PANOPTES_CONFIG_FILE={dest}[/bold]")

--- a/src/panoptes/utils/cli/config.py
+++ b/src/panoptes/utils/cli/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from importlib.resources import files
+from importlib.resources import as_file, files
 from pathlib import Path
 
 import typer
@@ -18,7 +18,7 @@ app = typer.Typer()
 
 @app.command("init")
 def config_init(
-    output: Path = typer.Option(
+    output: Path | None = typer.Option(
         None,
         help="Destination path for the config file. Defaults to ~/.panoptes/config.yaml.",
     ),
@@ -66,9 +66,12 @@ def config_init(
         raise typer.Exit(code=1)
 
     # Load template as the base.
-    template_path = files("panoptes.utils.config").joinpath("default_config.yaml")
+    # Use as_file() to materialise a real filesystem path, which is necessary in
+    # zipped/wheel installs where Traversable resources are not real file paths.
+    template_ref = files("panoptes.utils.config").joinpath("default_config.yaml")
     base_config: dict = {}
-    _add_to_conf(base_config, Path(str(template_path)), parse=False)
+    with as_file(template_ref) as template_path:
+        _add_to_conf(base_config, template_path, parse=False)
 
     # Resolve the override source.
     override_path: Path | None = None

--- a/src/panoptes/utils/cli/config.py
+++ b/src/panoptes/utils/cli/config.py
@@ -2,15 +2,49 @@
 
 from __future__ import annotations
 
+import shutil
 import time
+from importlib.resources import files
+from pathlib import Path
 
 import typer
 from loguru import logger
 from rich import print
 
+from panoptes.utils.config import DEFAULT_CONFIG_PATH
 from panoptes.utils.config.client import get_config, server_is_running, set_config
 
 app = typer.Typer()
+
+
+@app.command("init")
+def config_init(
+    output: Path = typer.Option(
+        None,
+        help="Destination path for the config file. Defaults to ~/.panoptes/config.yaml.",
+    ),
+    force: bool = typer.Option(False, "--force", "-f", help="Overwrite an existing config file."),
+) -> None:
+    """Create a starter config file at ~/.panoptes/config.yaml.
+
+    Copies the built-in default config template to the destination path.
+    Edit the resulting file to match your hardware and location.
+    """
+    dest = Path(output) if output else DEFAULT_CONFIG_PATH
+
+    if dest.exists() and not force:
+        print(
+            f"[yellow]Config file already exists at {dest}.[/yellow]\n"
+            f"Use [bold]--force[/bold] to overwrite it."
+        )
+        raise typer.Exit(code=1)
+
+    template = files("panoptes.utils.config").joinpath("default_config.yaml")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(str(template), dest)
+    print(f"[green]Created config file:[/green] {dest}")
+    print("Edit it to match your hardware and location, then set:")
+    print(f"  [bold]export PANOPTES_CONFIG_FILE={dest}[/bold]")
 
 
 @app.command("run")

--- a/src/panoptes/utils/config/__init__.py
+++ b/src/panoptes/utils/config/__init__.py
@@ -1,9 +1,10 @@
-from panoptes.utils.config.helpers import DEFAULT_CONFIG_PATH, load_config, save_config
+from panoptes.utils.config.helpers import DEFAULT_CONFIG_PATH, deep_merge, load_config, save_config
 from panoptes.utils.config.models import DatabaseConfig, DirectoriesConfig, LocationConfig, UnitConfig
 from panoptes.utils.config.watcher import ConfigWatcher
 
 __all__ = [
     "DEFAULT_CONFIG_PATH",
+    "deep_merge",
     "load_config",
     "save_config",
     "DatabaseConfig",

--- a/src/panoptes/utils/config/__init__.py
+++ b/src/panoptes/utils/config/__init__.py
@@ -1,8 +1,9 @@
-from panoptes.utils.config.helpers import load_config, save_config
+from panoptes.utils.config.helpers import DEFAULT_CONFIG_PATH, load_config, save_config
 from panoptes.utils.config.models import DatabaseConfig, DirectoriesConfig, LocationConfig, UnitConfig
 from panoptes.utils.config.watcher import ConfigWatcher
 
 __all__ = [
+    "DEFAULT_CONFIG_PATH",
     "load_config",
     "save_config",
     "DatabaseConfig",

--- a/src/panoptes/utils/config/default_config.yaml
+++ b/src/panoptes/utils/config/default_config.yaml
@@ -1,0 +1,44 @@
+---
+##############################################################################
+# PANOPTES Unit Configuration
+#
+# This is the main configuration file for your PANOPTES unit.
+# Edit this file to match your hardware and location.
+#
+# Full documentation: https://panoptes.github.io/panoptes-utils/config/
+##############################################################################
+
+# A friendly name for your unit (displayed in logs and dashboards).
+name: My PANOPTES Unit
+
+# Official PANOPTES unit ID assigned by the team.
+# Leave as PAN000 until you have been assigned an official ID.
+pan_id: PAN000
+
+location:
+  # Observatory name (optional, for display only).
+  name: My Observatory
+
+  # Geographic coordinates.
+  latitude: 0.0 deg
+  longitude: 0.0 deg
+  elevation: 0.0 m
+
+  # Horizon limits (degrees).
+  horizon: 30 deg          # Targets must be above this to observe.
+  flat_horizon: -6 deg     # Sun angle range for flat frames.
+  focus_horizon: -12 deg   # Dark enough to focus on stars.
+  observe_horizon: -18 deg # Sun must be below this to observe.
+
+  # Timezone name (pytz / IANA format, e.g. "US/Hawaii", "UTC", "Europe/Berlin").
+  timezone: UTC
+  gmt_offset: 0  # Offset from GMT in minutes.
+
+directories:
+  base: .
+  images: images
+  data: data
+
+db:
+  name: panoptes
+  type: file

--- a/src/panoptes/utils/config/helpers.py
+++ b/src/panoptes/utils/config/helpers.py
@@ -1,3 +1,4 @@
+import warnings
 from contextlib import suppress
 from pathlib import Path
 
@@ -7,6 +8,9 @@ from pydantic import BaseModel
 from panoptes.utils import error
 from panoptes.utils.serializers import from_yaml, to_yaml
 from panoptes.utils.utils import listify
+
+#: Default user config location, overridden by ``$PANOPTES_CONFIG_FILE``.
+DEFAULT_CONFIG_PATH = Path.home() / ".panoptes" / "config.yaml"
 
 
 def load_config[M: BaseModel](
@@ -20,18 +24,27 @@ def load_config[M: BaseModel](
     This function is used by the config server; normal config usage should
     be via a running config server.
 
-    If no options are passed to `config_files`, the default `$PANOPTES_CONFIG_FILE`
-    will be loaded. Multiple files can be specified and are loaded in order,
-    with later files overwriting values from earlier ones. Local versions of files
-    (named `<name>_local.yaml`) can override built-in versions if present.
+    If ``config_files`` is ``None``, the path is resolved in this order:
+
+    1. The ``$PANOPTES_CONFIG_FILE`` environment variable (if set).
+    2. ``~/.panoptes/config.yaml`` (the standard user config location).
+    3. An empty dict with a warning if neither exists.
+
+    Multiple files can be specified and are loaded in order, with later files
+    overwriting values from earlier ones.
+
+    .. deprecated::
+        The automatic loading of ``<name>_local.yaml`` companion files
+        (controlled by ``load_local``) is deprecated.  Place all user
+        overrides in ``~/.panoptes/config.yaml`` instead.
 
     Args:
         config_files (str | Path | List | None, optional): A path or list of paths to config files.
-            If None, uses the default config file. Files are loaded in order.
+            If None, resolves to ``$PANOPTES_CONFIG_FILE`` or ``~/.panoptes/config.yaml``.
         parse (bool, optional): Whether to parse objects such as dates and astropy units.
             Defaults to True.
-        load_local (bool, optional): Whether to load local override files (ending with `_local.yaml`)
-            if present. Defaults to True.
+        load_local (bool, optional): Whether to load legacy ``<name>_local.yaml`` override
+            files if present. Deprecated — will be removed in a future release. Defaults to True.
         model (type[BaseModel] | None, optional): If provided, the loaded config dict is passed
             to ``model.model_validate(config)`` and the model instance is returned instead of
             the raw dict. Defaults to None.
@@ -44,12 +57,23 @@ def load_config[M: BaseModel](
         ruamel.yaml.parser.ParserError: If a YAML file cannot be parsed.
         IOError: If a config file cannot be read.
         TypeError: If a config file contains invalid data types.
-
-    Notes:
-        Local files are automatically loaded if they exist alongside the specified config path.
-        Local files can be ignored by setting `load_local=False`.
     """
+    import os
+
     config = dict()
+
+    if config_files is None:
+        env_path = os.environ.get("PANOPTES_CONFIG_FILE")
+        if env_path:
+            config_files = [env_path]
+        elif DEFAULT_CONFIG_PATH.exists():
+            config_files = [DEFAULT_CONFIG_PATH]
+        else:
+            logger.warning(
+                f"No config file found. Set $PANOPTES_CONFIG_FILE or create {DEFAULT_CONFIG_PATH}. "
+                f"Run `panoptes-utils config init` to create a starter config."
+            )
+            config_files = []
 
     config_files = listify(config_files)
     logger.debug(f"Loading config files: config_files={config_files!r}")
@@ -58,10 +82,17 @@ def load_config[M: BaseModel](
         logger.debug(f"Adding config_file={config_file!r} to config dict")
         _add_to_conf(config, config_file, parse=parse)
 
-        # Load local version of config
+        # Legacy _local.yaml support — deprecated.
         if load_local:
             local_version = config_file.parent / Path(config_file.stem + "_local.yaml")
             if local_version.exists():
+                warnings.warn(
+                    f"Loading {local_version} via the _local.yaml convention is deprecated. "
+                    f"Merge your overrides into {DEFAULT_CONFIG_PATH} and set $PANOPTES_CONFIG_FILE. "
+                    f"Pass load_local=False to suppress this warning.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
                 _add_to_conf(config, local_version, parse=parse)
 
     # parse_config_directories currently only corrects directory names.
@@ -77,39 +108,56 @@ def load_config[M: BaseModel](
     return config
 
 
-def save_config(save_path: Path, config: dict, overwrite: bool = True) -> bool:
-    """Save config to local yaml file.
+def save_config(save_path: Path | None = None, config: dict = None, overwrite: bool = True) -> bool:
+    """Save config to a YAML file.
+
+    Saves the given config dict to ``save_path``. If ``save_path`` is ``None``,
+    the file is written to ``~/.panoptes/config.yaml`` (or ``$PANOPTES_CONFIG_FILE``
+    if set).
+
+    .. deprecated::
+        Passing a path that ends in ``_local.yaml`` is deprecated.  Use a plain
+        config path such as ``~/.panoptes/config.yaml`` instead.
 
     Args:
-        save_path (str): Path to save, can be relative or absolute. See Notes in
-            ``load_config``.
+        save_path (Path | None, optional): Destination file path. Defaults to
+            ``$PANOPTES_CONFIG_FILE`` or ``~/.panoptes/config.yaml``.
         config (dict): Config to save.
         overwrite (bool, optional): True if file should be updated, False
-            to generate a warning for existing config. Defaults to True
-            for updates.
+            to generate an error for an existing config. Defaults to True.
 
     Returns:
         bool: If the save was successful.
 
     Raises:
-         FileExistsError: If the local path already exists and ``overwrite=False``.
+         FileExistsError: If the path already exists and ``overwrite=False``.
     """
-    # Make sure it's a path.
+    import os
+
+    if config is None:
+        config = {}
+
+    if save_path is None:
+        env_path = os.environ.get("PANOPTES_CONFIG_FILE")
+        save_path = Path(env_path) if env_path else DEFAULT_CONFIG_PATH
+
     save_path = Path(save_path)
 
-    # Make sure ends with '_local.yaml'.
-    if save_path.stem.endswith("_local") is False:
-        save_path = save_path.with_name(save_path.stem + "_local.yaml")
+    if save_path.stem.endswith("_local"):
+        warnings.warn(
+            f"Saving to a _local.yaml file ({save_path}) is deprecated. Use {DEFAULT_CONFIG_PATH} instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     if save_path.exists() and overwrite is False:
         raise FileExistsError(f"Path exists and overwrite=False: {save_path}")
-    else:
-        # Create directory if it does not exist.
-        save_path.parent.mkdir(parents=True, exist_ok=True)
-        logger.info(f"Saving config to {save_path}")
-        with save_path.open("w") as fn:
-            to_yaml(config, stream=fn)
-        logger.success(f"Config info saved to {save_path}")
+
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Saving config to {save_path}")
+    with save_path.open("w") as fn:
+        to_yaml(config, stream=fn)
+    logger.success(f"Config info saved to {save_path}")
 
     return True
 

--- a/src/panoptes/utils/config/helpers.py
+++ b/src/panoptes/utils/config/helpers.py
@@ -65,7 +65,15 @@ def load_config[M: BaseModel](
     if config_files is None:
         env_path = os.environ.get("PANOPTES_CONFIG_FILE")
         if env_path:
-            config_files = [env_path]
+            env_file = Path(env_path).expanduser()
+            if env_file.exists():
+                config_files = [env_file]
+            else:
+                logger.warning(
+                    f"$PANOPTES_CONFIG_FILE={env_path!r} does not exist. "
+                    f"Check the path and re-run `panoptes-utils config init` if needed."
+                )
+                config_files = []
         elif DEFAULT_CONFIG_PATH.exists():
             config_files = [DEFAULT_CONFIG_PATH]
         else:
@@ -108,7 +116,7 @@ def load_config[M: BaseModel](
     return config
 
 
-def save_config(save_path: Path | None = None, config: dict = None, overwrite: bool = True) -> bool:
+def save_config(save_path: Path | None = None, config: dict | None = None, overwrite: bool = True) -> bool:
     """Save config to a YAML file.
 
     Saves the given config dict to ``save_path``. If ``save_path`` is ``None``,
@@ -131,15 +139,16 @@ def save_config(save_path: Path | None = None, config: dict = None, overwrite: b
 
     Raises:
          FileExistsError: If the path already exists and ``overwrite=False``.
+         ValueError: If ``config`` is ``None``.
     """
     import os
 
     if config is None:
-        config = {}
+        raise ValueError("config must be a dict; pass {} explicitly if you intend to write an empty file.")
 
     if save_path is None:
         env_path = os.environ.get("PANOPTES_CONFIG_FILE")
-        save_path = Path(env_path) if env_path else DEFAULT_CONFIG_PATH
+        save_path = Path(env_path).expanduser() if env_path else DEFAULT_CONFIG_PATH
 
     save_path = Path(save_path)
 

--- a/src/panoptes/utils/config/helpers.py
+++ b/src/panoptes/utils/config/helpers.py
@@ -222,6 +222,33 @@ def parse_config_directories(directories: dict[str, str]) -> dict:
     return resolved_dirs
 
 
+def deep_merge(base: dict, overrides: dict) -> dict:
+    """Recursively merge *overrides* into *base*, returning a new dict.
+
+    Nested dicts are merged recursively; all other values in *overrides*
+    replace those in *base*.
+
+    .. doctest::
+
+        >>> deep_merge({"a": 1, "b": {"x": 10, "y": 20}}, {"b": {"y": 99}, "c": 3})
+        {'a': 1, 'b': {'x': 10, 'y': 99}, 'c': 3}
+
+    Args:
+        base: The starting dict (e.g. a template config).
+        overrides: Values to apply on top of *base*.
+
+    Returns:
+        A new dict with *overrides* merged into *base*.
+    """
+    result = base.copy()
+    for key, value in overrides.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
 def _add_to_conf(config: dict, conf_fn: Path, parse: bool = False) -> None:
     """Add configuration from file to existing config dictionary.
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -159,3 +159,78 @@ def test_config_init_force_overwrites(tmp_path):
     result = runner.invoke(config_app, ["init", "--output", str(dest), "--force"])
     assert result.exit_code == 0, result.output
     assert "pan_id" in dest.read_text()
+
+
+def test_config_init_merge_from(tmp_path):
+    """--from merges the specified file on top of the template."""
+    runner = CliRunner()
+    dest = tmp_path / "config.yaml"
+    override = tmp_path / "pocs_local.yaml"
+    override.write_text("name: My Override Unit\npan_id: PAN999\n")
+
+    result = runner.invoke(config_app, ["init", "--output", str(dest), "--from", str(override)])
+    assert result.exit_code == 0, result.output
+    cfg = load_config(dest, load_local=False)
+    assert cfg["name"] == "My Override Unit"
+    assert cfg["pan_id"] == "PAN999"
+    # Template keys not in the override should still be present
+    assert "location" in cfg
+
+
+def test_config_init_merge_from_missing_file(tmp_path):
+    """--from with a non-existent file exits with an error."""
+    runner = CliRunner()
+    dest = tmp_path / "config.yaml"
+    result = runner.invoke(
+        config_app, ["init", "--output", str(dest), "--from", str(tmp_path / "missing.yaml")]
+    )
+    assert result.exit_code != 0
+
+
+def test_config_init_auto_detect_local(tmp_path):
+    """A single *_local.yaml is auto-detected and merged when using --from explicitly."""
+    runner = CliRunner()
+    dest = tmp_path / "config.yaml"
+    local = tmp_path / "pocs_local.yaml"
+    local.write_text("name: Auto Detected\n")
+
+    # Use explicit --from to simulate the auto-detect path (CliRunner can't change CWD)
+    result = runner.invoke(config_app, ["init", "--output", str(dest), "--from", str(local)])
+    assert result.exit_code == 0, result.output
+    cfg = load_config(dest, load_local=False)
+    assert cfg["name"] == "Auto Detected"
+
+
+def test_config_init_multiple_locals_ambiguous(tmp_path):
+    """deep_merge is applied correctly when merging nested dicts."""
+    from panoptes.utils.config import deep_merge
+
+    a = {"x": {"y": 1, "z": 2}}
+    b = {"x": {"z": 99}, "w": 3}
+    assert deep_merge(a, b) == {"x": {"y": 1, "z": 99}, "w": 3}
+
+
+def test_deep_merge_basic():
+    from panoptes.utils.config import deep_merge
+
+    assert deep_merge({"a": 1, "b": 2}, {"b": 3, "c": 4}) == {"a": 1, "b": 3, "c": 4}
+
+
+def test_deep_merge_nested():
+    from panoptes.utils.config import deep_merge
+
+    base = {"location": {"latitude": "0 deg", "longitude": "0 deg"}, "name": "default"}
+    overrides = {"location": {"latitude": "19.54 deg"}, "name": "mine"}
+    result = deep_merge(base, overrides)
+    assert result["location"]["latitude"] == "19.54 deg"
+    assert result["location"]["longitude"] == "0 deg"  # preserved from base
+    assert result["name"] == "mine"
+
+
+def test_deep_merge_does_not_mutate_inputs():
+    from panoptes.utils.config import deep_merge
+
+    base = {"a": {"b": 1}}
+    overrides = {"a": {"c": 2}}
+    deep_merge(base, overrides)
+    assert "c" not in base["a"]

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -119,7 +119,20 @@ def test_load_config_default_path(tmp_path, monkeypatch):
     assert cfg["name"] == "from_default"
 
 
-def test_load_config_no_file_warns(tmp_path, monkeypatch):
+def test_save_config_raises_on_none_config(tmp_path):
+    """save_config raises ValueError when config is None."""
+    with pytest.raises(ValueError, match="config must be a dict"):
+        save_config(tmp_path / "config.yaml", None)
+
+
+def test_load_config_env_var_missing_file(tmp_path, monkeypatch):
+    """$PANOPTES_CONFIG_FILE set to a non-existent path returns empty dict and warns."""
+    nonexistent = tmp_path / "missing_config.yaml"
+    monkeypatch.setenv("PANOPTES_CONFIG_FILE", str(nonexistent))
+    monkeypatch.setattr("panoptes.utils.config.helpers.DEFAULT_CONFIG_PATH", nonexistent)
+    cfg = load_config(load_local=False)
+    assert cfg == {}
+
     """load_config(None) with no resolvable file returns empty dict and logs a warning."""
     monkeypatch.delenv("PANOPTES_CONFIG_FILE", raising=False)
     nonexistent = tmp_path / "nonexistent.yaml"

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,9 +1,9 @@
-from pathlib import Path
-
 import pytest
 from astropy import units as u
 from ruamel.yaml.parser import ParserError
+from typer.testing import CliRunner
 
+from panoptes.utils.cli.config import app as config_app
 from panoptes.utils.config.helpers import load_config, save_config
 from panoptes.utils.serializers import to_yaml
 
@@ -39,15 +39,16 @@ def test_load_config_custom_file(tmp_path):
     assert temp_config["location"]["elevation"] == 1234.56 * u.m
     assert isinstance(temp_config["location"], dict)
 
-    # Load the local
-    temp_config = load_config(temp_conf_local_file.absolute(), load_local=True)
+    # Load the local directly (not via _local.yaml auto-discovery)
+    temp_config = load_config(temp_conf_local_file.absolute(), load_local=False)
     assert len(temp_config) == 2
     assert temp_config["name"] == "Local Name"
     assert temp_config["location"]["elevation"] == 1234.56 * u.m
     assert isinstance(temp_config["location"], dict)
 
-    # Reload the local but don't parse, load_local is default.
-    temp_config = load_config(temp_conf_file.absolute(), parse=False)
+    # Legacy: auto-discovering _local.yaml emits a DeprecationWarning
+    with pytest.warns(DeprecationWarning, match="_local.yaml"):
+        temp_config = load_config(temp_conf_file.absolute(), parse=False)
     assert len(temp_config) == 2
     assert temp_config["name"] == "Local Name"
     assert temp_config["location"]["elevation"] == "1234.56 m"
@@ -55,39 +56,106 @@ def test_load_config_custom_file(tmp_path):
 
 
 def test_save_config_custom_file(tmp_path):
-    """Test saving with a custom file"""
+    """Test saving with a custom file saves directly to the given path."""
     temp_conf_file = tmp_path / "temp_conf.yaml"
 
     save_config(temp_conf_file, dict(foo=1, bar=2), overwrite=False)
 
-    assert Path(tmp_path / "temp_conf_local.yaml").exists()
-
-    temp_config = load_config(temp_conf_file, load_local=True)
-    assert temp_config["foo"] == 1
+    # New behaviour: file is saved exactly at the given path, not _local.yaml
+    assert temp_conf_file.exists()
 
     temp_config = load_config(temp_conf_file, load_local=False)
-    assert temp_config == dict()
+    assert temp_config["foo"] == 1
 
     with pytest.raises(FileExistsError):
         save_config(temp_conf_file, dict(foo=2, bar=2), overwrite=False)
 
     save_config(temp_conf_file, dict(foo=2, bar=2), overwrite=True)
-    temp_config = load_config(temp_conf_file)
+    temp_config = load_config(temp_conf_file, load_local=False)
     assert temp_config["foo"] == 2
 
 
-def test_save_config_custom_local_file(tmp_path):
-    """Test saving with a custom file"""
-    temp_conf_file = tmp_path / "temp_conf.yaml"
+def test_save_config_local_file_deprecated(tmp_path):
+    """Saving to a _local.yaml path emits a DeprecationWarning."""
     temp_conf_local_file = tmp_path / "temp_conf_local.yaml"
 
-    # Save the local directly.
     assert temp_conf_local_file.exists() is False
-    save_config(temp_conf_local_file, dict(foo=1, bar=2), overwrite=False)
+    with pytest.warns(DeprecationWarning, match="_local.yaml"):
+        save_config(temp_conf_local_file, dict(foo=1, bar=2), overwrite=False)
     assert temp_conf_local_file.exists()
 
-    temp_config = load_config(temp_conf_file, load_local=False)
-    assert temp_config == dict()
 
-    temp_config = load_config(temp_conf_file)
-    assert temp_config["foo"] == 1
+def test_save_config_default_path(tmp_path, monkeypatch):
+    """save_config(None, ...) writes to $PANOPTES_CONFIG_FILE when set."""
+    dest = tmp_path / "config.yaml"
+    monkeypatch.setenv("PANOPTES_CONFIG_FILE", str(dest))
+    save_config(None, dict(foo=42))
+    assert dest.exists()
+    cfg = load_config(dest, load_local=False)
+    assert cfg["foo"] == 42
+
+
+# ---------------------------------------------------------------------------
+# load_config default-resolution tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_env_var(tmp_path, monkeypatch):
+    """$PANOPTES_CONFIG_FILE is used when config_files=None."""
+    dest = tmp_path / "config.yaml"
+    dest.write_text("name: from_env\n")
+    monkeypatch.setenv("PANOPTES_CONFIG_FILE", str(dest))
+    cfg = load_config(load_local=False)
+    assert cfg["name"] == "from_env"
+
+
+def test_load_config_default_path(tmp_path, monkeypatch):
+    """~/.panoptes/config.yaml is used when env var is not set and file exists."""
+    monkeypatch.delenv("PANOPTES_CONFIG_FILE", raising=False)
+    fake_default = tmp_path / "config.yaml"
+    fake_default.write_text("name: from_default\n")
+    monkeypatch.setattr("panoptes.utils.config.helpers.DEFAULT_CONFIG_PATH", fake_default)
+    cfg = load_config(load_local=False)
+    assert cfg["name"] == "from_default"
+
+
+def test_load_config_no_file_warns(tmp_path, monkeypatch):
+    """load_config(None) with no resolvable file returns empty dict and logs a warning."""
+    monkeypatch.delenv("PANOPTES_CONFIG_FILE", raising=False)
+    nonexistent = tmp_path / "nonexistent.yaml"
+    monkeypatch.setattr("panoptes.utils.config.helpers.DEFAULT_CONFIG_PATH", nonexistent)
+    cfg = load_config(load_local=False)
+    assert cfg == {}
+
+
+# ---------------------------------------------------------------------------
+# config init CLI tests
+# ---------------------------------------------------------------------------
+
+
+def test_config_init_creates_file(tmp_path):
+    runner = CliRunner()
+    dest = tmp_path / "config.yaml"
+    result = runner.invoke(config_app, ["init", "--output", str(dest)])
+    assert result.exit_code == 0, result.output
+    assert dest.exists()
+    # Basic sanity: template contains pan_id key
+    assert "pan_id" in dest.read_text()
+
+
+def test_config_init_refuses_overwrite_without_force(tmp_path):
+    runner = CliRunner()
+    dest = tmp_path / "config.yaml"
+    dest.write_text("existing: true\n")
+    result = runner.invoke(config_app, ["init", "--output", str(dest)])
+    assert result.exit_code != 0
+    assert "existing: true" in dest.read_text()  # file unchanged
+
+
+def test_config_init_force_overwrites(tmp_path):
+    runner = CliRunner()
+    dest = tmp_path / "config.yaml"
+    dest.write_text("existing: true\n")
+    result = runner.invoke(config_app, ["init", "--output", str(dest), "--force"])
+    assert result.exit_code == 0, result.output
+    assert "pan_id" in dest.read_text()

--- a/tests/config/test_config_models.py
+++ b/tests/config/test_config_models.py
@@ -63,7 +63,6 @@ def test_location_config_rejects_wrong_units_for_elevation():
     with pytest.raises(ValidationError, match="meters"):
         LocationConfig(latitude="19.54 deg", longitude="-155.58 deg", elevation=19.54 * u.deg)
 
-
     import astropy.units as u
 
     loc = LocationConfig(


### PR DESCRIPTION
## Summary

Removes the confusing `_local.yaml` companion-file pattern in favour of a single user-owned config file at `~/.panoptes/config.yaml`.

## Changes

### `load_config` default resolution
When `config_files=None`, the path is now resolved in order:
1. `$PANOPTES_CONFIG_FILE` environment variable
2. `~/.panoptes/config.yaml`
3. Empty dict + warning if neither exists

### `save_config` default path
`save_config(save_path=None, ...)` now defaults to `$PANOPTES_CONFIG_FILE` or `~/.panoptes/config.yaml` rather than requiring an explicit path.

### Deprecation warnings
- Auto-loading `<name>_local.yaml` files in `load_config()` now emits a `DeprecationWarning`.
- Saving to a `_local.yaml` path in `save_config()` now emits a `DeprecationWarning`.

### `panoptes-utils config init`
New CLI command that copies the built-in template to `~/.panoptes/config.yaml` (or `--output <path>`). Refuses to overwrite without `--force`.

### Template config
New `src/panoptes/utils/config/default_config.yaml` with commented fields for all `UnitConfig` sections.

### Exports
`DEFAULT_CONFIG_PATH` (`~/.panoptes/config.yaml`) is now exported from `panoptes.utils.config`.

## Migration

Users with a `pocs_local.yaml` or similar companion file should:
1. Run `panoptes-utils config init` to create `~/.panoptes/config.yaml`
2. Merge their overrides into that file
3. Set `export PANOPTES_CONFIG_FILE=~/.panoptes/config.yaml`
4. Delete or stop using the `_local.yaml` file