### PR TITLE
feat: add config store, deprecate HTTP config server/client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,13 +127,14 @@ panoptes-utils/
 - Use `uv sync --extra <package>` to install optional extras
 - Add to `[dependency-groups]` for development dependencies (testing, lint, etc.)
 - Consider which extras group the dependency belongs to:
-  - `config`: Configuration server dependencies
+  - `config-server`: Configuration server dependencies
   - `images`: Image processing dependencies
   - `testing`: Testing tools
   - `docs`: Documentation building
 
 **Optional Dependencies:**
-- `config`: fastapi, uvicorn, scalpl for deprecated HTTP config server (no new dependencies needed for config store)
+- `config-server`: fastapi, uvicorn, scalpl for deprecated HTTP config server (no new dependencies needed for config store)
+- `config`: backward-compatible alias for `config-server`
 - `images`: matplotlib, photutils, pillow for image processing
 - `testing`: pytest, coverage, and testing tools
 - `docs`: MkDocs and documentation tools

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This document provides guidelines for AI coding agents working with the PANOPTES
 
 ## Project Overview
 
-PANOPTES Utilities is a Python library providing astronomical utilities for the PANOPTES ecosystem. It includes CLI tools for image processing, a configuration server, and various utility modules for astronomical data processing. This library serves as the foundation for other PANOPTES projects like [POCS](https://github.com/panoptes/POCS).
+PANOPTES Utilities is a Python library providing astronomical utilities for the PANOPTES ecosystem. It includes CLI tools for image processing, a file-based configuration store, a telemetry server, and various utility modules for astronomical data processing. This library serves as the foundation for other PANOPTES projects like [POCS](https://github.com/panoptes/POCS).
 
 **Key Characteristics:**
 - **Language:** Python 3.12+ (type hints expected)
@@ -133,7 +133,7 @@ panoptes-utils/
   - `docs`: Documentation building
 
 **Optional Dependencies:**
-- `config`: fastapi, uvicorn, scalpl for configuration server
+- `config`: fastapi, uvicorn, scalpl for deprecated HTTP config server (no new dependencies needed for config store)
 - `images`: matplotlib, photutils, pillow for image processing
 - `testing`: pytest, coverage, and testing tools
 - `docs`: MkDocs and documentation tools
@@ -173,23 +173,53 @@ panoptes-utils/
 
 **Location:** `src/panoptes/utils/config/`
 
-The configuration system provides centralized configuration management through a client-server architecture.
+The configuration system provides a lightweight, **file-based in-memory config store** as
+the single source of truth for runtime configuration.  No server process is required.
 
-**Components:**
-- `server.py`: FastAPI+uvicorn configuration server
-- `client.py`: Configuration client for accessing server
-- CLI is now under `panoptes-utils config` (see `src/panoptes/utils/cli/config.py`)
+**Key components:**
+- `store.py`: Module-level in-memory store — **the canonical config API** (new, preferred)
+- `models.py`: Pydantic v2 typed models (`UnitConfig`, `LocationConfig`, etc.)
+- `watcher.py`: `ConfigWatcher` — watches a YAML file and fires callbacks on change
+- `server.py` / `client.py`: **Deprecated** HTTP server/client — do not use for new code
+- CLI is under `panoptes-utils config` (`src/panoptes/utils/cli/config.py`)
+
+**Using the config store:**
+```python
+from panoptes.utils.config.store import init_config, get_config, set_config
+
+# Initialise once at process startup (idempotent)
+init_config("path/to/config.yaml")
+
+# Read a value using dotted notation
+horizon = get_config("location.horizon")          # e.g. 30.0
+
+# Write a value (persists back to the YAML file by default)
+set_config("location.horizon", 45)
+```
+
+The store is a **module-level singleton** — all code in the same process shares the same
+loaded dict.  Tests must use the `reset_config_store` autouse fixture
+(defined in `tests/config/conftest.py`) to isolate state between test cases.
+
+**Environment variable:**
+```bash
+export PANOPTES_CONFIG_FILE=~/.panoptes/config.yaml
+```
+When set, `init_config()` with no arguments resolves this path automatically.
+
+**CLI quick reference (no server required):**
+```bash
+panoptes-utils config init                         # create starter config file
+panoptes-utils config get location.elevation       # read a value
+panoptes-utils config set location.horizon '30 deg'  # write a value
+```
 
 **When modifying:**
-- Understand client-server communication protocol
-- Preserve backward compatibility with POCS and other clients
+- The store is a module-level singleton; ensure tests use the `reset_config_store` fixture
+- Preserve the `get_config` / `set_config` / `init_config` public API
 - Test with `tests/testing.yaml` configuration
-- Ensure thread safety for concurrent access
-
-**Starting the config server:**
-```bash
-panoptes-utils config run --config-file tests/testing.yaml
-```
+- `server.py` and `client.py` are deprecated — do not add new features to them
+- Track full removal of the HTTP server/client in issue #366
 
 ### CLI Module
 
@@ -208,7 +238,7 @@ Command-line tools built with Typer.
 
 **Available commands:**
 - `panoptes-utils image`: Image processing commands
-- `panoptes-utils config`: Configuration server management
+- `panoptes-utils config`: Configuration store (get/set/init)
 - `panoptes-utils telemetry`: Telemetry server management and migration
 
 ### Image Processing Module
@@ -317,30 +347,26 @@ Data posted via `post_event()` is serialized with `to_json()` before transmissio
 - `directories`: Data storage locations
 - Custom sections for specific modules
 
-### Config Server
+### Config Store
 
-The configuration server provides a REST API for centralized configuration management.
+The config store (`panoptes.utils.config.store`) is the standard way to access
+configuration at runtime.  It loads a YAML file into memory once and exposes a simple
+get/set API to all code in the same process.
 
-**Starting the config server locally:**
-```bash
-# For development
-panoptes-utils config run --config-file tests/testing.yaml
-
-# With custom host/port
-panoptes-utils config run --host 0.0.0.0 --port 8765 --config-file tests/testing.yaml
+**Initialise once at process startup:**
+```python
+from panoptes.utils.config.store import init_config
+init_config("tests/testing.yaml")   # or from $PANOPTES_CONFIG_FILE
 ```
 
-**Notes:**
-- Default port is 8765
-- Server provides REST API for configuration access
-- Used by POCS and other PANOPTES components
+> **Deprecated:** `panoptes-utils config run / stop` (HTTP server) and
+> `panoptes.utils.config.client` are deprecated.  Use the store instead.
 
 **When modifying configuration:**
 - Maintain backward compatibility when possible
 - Update example configs in `tests/`
 - Document new configuration options
 - Validate configuration structure
-- Restart config server after modifying config files
 
 ## Common Tasks
 
@@ -630,7 +656,7 @@ When making changes, update:
 ## Common Pitfalls
 
 1. **System Dependencies:** Not all systems have astrometry.net, dcraw installed
-2. **Config Server Availability:** Code should handle missing config server gracefully
+2. **Config Store Init:** Call `init_config()` at process startup; check `PANOPTES_CONFIG_FILE` is set
 3. **Optional Dependencies:** Features using optional deps should fail gracefully
 4. **File Paths:** Use `pathlib.Path`, handle both absolute and relative paths
 5. **Time Zones:** Use UTC for all astronomical calculations
@@ -743,8 +769,8 @@ uv run ruff format --check .
 # Build package
 uv build
 
-# Start config server
-panoptes-utils config run --config-file tests/testing.yaml
+# Initialise config store
+panoptes-utils config init   # creates ~/.panoptes/config.yaml from template
 
 # View CLI help
 panoptes-utils --help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 * Root `conftest.py` now initialises the config store from `tests/testing.yaml` instead of starting an HTTP server.
 * `tests/config/test_config_server.py` now tests the in-memory store (not the HTTP server).
 * Split `config` optional-dependency extra into `config-server` (fastapi, uvicorn, scalpl, PyYAML — for the deprecated HTTP server). The config store requires no extras.
-* `set_config` now persists changes to the YAML file by default (`persist=True`), matching the behaviour of the old HTTP client. Pass `persist=False` for an in-memory-only update.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * `panoptes-utils config get` and `panoptes-utils config set` now read/write directly from the YAML file via the config store. The `--host`/`--port` options are removed; use `--config-file` (or `$PANOPTES_CONFIG_FILE`) instead.
 * Root `conftest.py` now initialises the config store from `tests/testing.yaml` instead of starting an HTTP server.
 * `tests/config/test_config_server.py` now tests the in-memory store (not the HTTP server).
+* Split `config` optional-dependency extra into `config-server` (fastapi, uvicorn, scalpl, PyYAML — for the deprecated HTTP server) and `config` (alias for backward compatibility). The config store requires no extras.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 * `panoptes-utils config get` and `panoptes-utils config set` now read/write directly from the YAML file via the config store. The `--host`/`--port` options are removed; use `--config-file` (or `$PANOPTES_CONFIG_FILE`) instead.
 * Root `conftest.py` now initialises the config store from `tests/testing.yaml` instead of starting an HTTP server.
 * `tests/config/test_config_server.py` now tests the in-memory store (not the HTTP server).
-* Split `config` optional-dependency extra into `config-server` (fastapi, uvicorn, scalpl, PyYAML — for the deprecated HTTP server) and `config` (alias for backward compatibility). The config store requires no extras.
+* Split `config` optional-dependency extra into `config-server` (fastapi, uvicorn, scalpl, PyYAML — for the deprecated HTTP server). The config store requires no extras.
+* `set_config` now persists changes to the YAML file by default (`persist=True`), matching the behaviour of the old HTTP client. Pass `persist=False` for an in-memory-only update.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Added
+
+* Added `panoptes.utils.config.store` — an in-memory config store with `init_config`, `reload_config`, `get_config`, and `set_config`. Replaces the HTTP config server/client for all local config access.
+
+### Changed
+
+* `panoptes-utils config get` and `panoptes-utils config set` now read/write directly from the YAML file via the config store. The `--host`/`--port` options are removed; use `--config-file` (or `$PANOPTES_CONFIG_FILE`) instead.
+* Root `conftest.py` now initialises the config store from `tests/testing.yaml` instead of starting an HTTP server.
+* `tests/config/test_config_server.py` now tests the in-memory store (not the HTTP server).
+
+### Deprecated
+
+* `panoptes.utils.config.client` — HTTP config client. Use `panoptes.utils.config.store` instead. Module emits a `DeprecationWarning` on import.
+* `panoptes.utils.config.server` — HTTP config server. Module emits a `DeprecationWarning` on import.
+* `panoptes-utils config run` and `panoptes-utils config stop` — emit `DeprecationWarning` at runtime. The HTTP server is no longer needed.
+
 ## 0.4.0 - 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,31 +72,27 @@ panoptes-utils image cr2 to-fits <file.cr2>
 panoptes-utils image fits solve <file.fits>
 ```
 
-### `config` — Configuration server
+### `config` — Configuration store
 
-Requires the `config` extra (`pip install "panoptes-utils[config]"`).
-
-Start a local key-value configuration server backed by a YAML file:
+Read and write configuration values from the YAML config file. No server process required.
 
 ```bash
-# Start the server
-panoptes-utils config run --config-file <path-to-file.yaml>
+# Initialise the config file from the built-in template
+panoptes-utils config init
 
 # Read a value (returns entire config if no key given)
 panoptes-utils config get location.elevation
 
 # Update a value
 panoptes-utils config set name "My Observatory"
-
-# Stop the server
-panoptes-utils config stop
 ```
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `PANOPTES_CONFIG_HOST` | Config server host address | `localhost` |
-| `PANOPTES_CONFIG_PORT` | Config server port | `6563` |
-| `PANOPTES_CONFIG_FILE` | YAML config file to load (CLI only) | — |
+| `PANOPTES_CONFIG_FILE` | Path to the YAML config file | `~/.panoptes/config.yaml` |
+
+> **Deprecated:** `panoptes-utils config run` / `config stop` (HTTP server) are deprecated.
+> Use `$PANOPTES_CONFIG_FILE` and the store directly instead.
 
 ### `telemetry` — Telemetry server
 

--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from loguru import logger
 from matplotlib import pyplot as plt
 
-from panoptes.utils.config.server import config_server
+from panoptes.utils.config.store import init_config
 from panoptes.utils.database import PanDB
 
 _all_databases = ["file", "memory"]
@@ -46,17 +46,9 @@ logger.log("testing", "*" * 25 + startup_message + "*" * 25)
 
 def pytest_configure(config) -> None:  # noqa: ANN001
     """Set up the testing."""
-    logger.info("Setting up the config server.")
-    config_file = "tests/testing.yaml"
-
-    host = "localhost"
-    port = "8765"
-
-    os.environ["PANOPTES_CONFIG_HOST"] = host
-    os.environ["PANOPTES_CONFIG_PORT"] = port
-
-    config_server(config_file, host="localhost", port=8765, load_local=False, save_local=False)
-    logger.success("Config server set up")
+    logger.info("Initialising config store from tests/testing.yaml.")
+    init_config("tests/testing.yaml")
+    logger.success("Config store initialised.")
 
     config.addinivalue_line("markers", "plate_solve: Tests that require astrometry.net")
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,7 @@ Options:
   --help                    Show this message and exit.
 
 Commands:
-  config    Manage the config server.
+  config    Manage configuration (get/set/init).
   image     Process an image.
   telemetry  Run the telemetry server.
 ```
@@ -30,23 +30,24 @@ Commands:
 
 ## config
 
-See [Config Server](config-server.md) for full documentation of the config subcommand.
+See [Configuration](config.md) for full documentation of the config store and CLI subcommand.
 
 Quick reference:
 
 ```bash
-# Start the config server
-panoptes-utils config run --config-file /path/to/config.yaml
+# Initialise a config file (writes ~/.panoptes/config.yaml from the built-in template)
+panoptes-utils config init
 
-# Read a value
+# Read a value (no server required)
 panoptes-utils config get location.elevation
 
 # Update a value
 panoptes-utils config set name "My Observatory"
-
-# Stop the server
-panoptes-utils config stop
 ```
+
+> **Note:** The `run` and `stop` subcommands (HTTP config server) are **deprecated** and will
+> be removed in a future release. Use the file-based store and the `$PANOPTES_CONFIG_FILE`
+> environment variable instead.
 
 ## image
 

--- a/docs/config-server.md
+++ b/docs/config-server.md
@@ -1,190 +1,49 @@
-# Config Server
+# Config Server (Deprecated)
 
-The config server is a lightweight FastAPI/uvicorn web service that provides centralised key/value configuration management. It can run on a local machine or a remote server and is the canonical way for PANOPTES components to share runtime configuration.
+> **Deprecated:**
+> The HTTP config server (`panoptes.utils.config.server`) and its client
+> (`panoptes.utils.config.client`) are deprecated as of `panoptes-utils` 0.X and
+> will be removed in a future release (tracked in
+> [#366](https://github.com/panoptes/panoptes-utils/issues/366)).
+>
+> Use the **[Config Store](config.md)** instead — it reads config directly from
+> the YAML file with no server process required.
 
-The configuration is a key/value system where keys and values must be serialisable as valid YAML (or JSON). Configuration can be seeded from an external YAML file; any values updated while the server is running are, by default, saved back to a local copy of that file.
+---
 
-> **Note:**
-> 
-> The config server is an optional feature. Install it with:
-> 
-> ```bash
-> pip install "panoptes-utils[config]"
-> ```
+## Migration
 
-The `panoptes-utils config` subcommand provides all interactions with the server:
-
-```bash
-$ panoptes-utils config --help
-Usage: panoptes-utils config [OPTIONS] COMMAND [ARGS]...
-
-  Manage the config server.
-
-Options:
-  --help  Show this message and exit.
-
-Commands:
-  get   Get a config value by dotted key name (e.g. 'location.elevation').
-  run   Run the config server and block until it stops.
-  set   Set a config value by dotted key name (e.g. 'location.elevation').
-  stop  Stop the config server.
-```
-
-Each subcommand has its own `--help` option. See below for specific usage.
-
-## Starting the config server
-
-### Command line
-
-To start the service from the command-line, use `panoptes-utils config run`:
-
-```bash
-$ panoptes-utils config run --help
-Usage: panoptes-utils config run [OPTIONS]
-
-  Run the config server and block until it stops.
-
-Options:
-  --host TEXT                       Host address to bind the config server to.
-                                    [env var: PANOPTES_CONFIG_HOST]
-  --port INTEGER                    Port number to bind the config server to.
-                                    [default: 6563; env var: PANOPTES_CONFIG_PORT]
-  --config-file TEXT                Path to the YAML config file to load.
-                                    [env var: PANOPTES_CONFIG_FILE]
-  --load-local / --no-load-local    Load local config files on startup.
-                                    [default: load-local]
-  --save-local / --no-save-local    Save config changes to the local file.
-                                    [default: save-local]
-  --heartbeat FLOAT                 Heartbeat interval in seconds.  [default: 2.0]
-  --startup-timeout FLOAT           Seconds to wait for the server to become ready.
-                                    [default: 30.0]
-  --help                            Show this message and exit.
-```
-
-Example — start the server with a custom config file:
-
-```bash
-$ panoptes-utils config run --config-file /path/to/config.yaml
-```
-
-Omitting `--config-file` starts the server with an empty configuration that can be populated via `panoptes-utils config set` or the Python client.
-
-### Python
-
-Start the server from Python, for instance inside a Jupyter notebook:
+Replace any use of the HTTP client with the config store:
 
 ```python
-from panoptes.utils.config.server import config_server
+# Before (deprecated)
+from panoptes.utils.config.client import get_config, set_config
 
-# Returns a multiprocessing.Process; starts the server automatically.
-server_process = config_server("path/to/config.yaml")
-...
-server_process.terminate()  # Or just exit the notebook/console
+value = get_config("location.horizon")
+set_config("location.horizon", 45)
+
+# After
+from panoptes.utils.config.store import get_config, init_config, set_config
+
+init_config("~/.panoptes/config.yaml")  # once at startup
+value = get_config("location.horizon")
+set_config("location.horizon", 45)
 ```
 
-## Options
-
-### load_local
-
-By default, the server looks for a `*_local.yaml` companion alongside the primary config file (e.g. `pocs_local.yaml` next to `pocs.yaml`). Any keys present in the local file override the primary config. This makes it easy to keep site-specific overrides separate from version-controlled defaults.
-
-Pass `--no-load-local` (or `load_local=False` in Python) to skip the local file entirely.
-
-### save_local
-
-When `--save-local` is active (the default), any `set` operations that modify the running config are automatically persisted back to the local file on disk.
-
-Pass `--no-save-local` (or `save_local=False` in Python) to treat the server as purely in-memory — useful for short-lived test sessions.
-
-## Stopping the config server
-
-### Command line
-
-Use `panoptes-utils config stop` to gracefully shut down a running server:
+Replace CLI usage:
 
 ```bash
-$ panoptes-utils config stop
-# Custom host/port:
-$ panoptes-utils config stop --host myhost --port 7000
+# Before (deprecated)
+panoptes-utils config run --config-file /path/to/config.yaml
+panoptes-utils config get location.elevation   # required a running server
+panoptes-utils config stop
+
+# After — no server needed
+export PANOPTES_CONFIG_FILE=/path/to/config.yaml
+panoptes-utils config get location.elevation
+panoptes-utils config set location.elevation "3400 m"
 ```
 
-When the server was started with `panoptes-utils config run` (foreground), pressing `Ctrl-c` also cleanly stops it.
+See the **[Configuration](config.md)** page for full documentation on the config store,
+typed models, and the file watcher.
 
-## Using the config server
-
-### Python
-
-The server can be queried and updated via the Python client:
-
-```python
-from panoptes.utils.config import client
-
-# Show the entire config.
-client.get_config('location')
-# {'elevation': 3400.0,
-#  'flat_horizon': -6.0,
-#  'focus_horizon': -12.0,
-#  'gmt_offset': -600.0,
-#  'horizon': 30,
-#  'latitude': 19.54,
-#  'longitude': -155.58,
-#  'name': 'Mauna Loa Observatory',
-#  'observe_horizon': -18.0,
-#  'timezone': 'US/Hawaii'}
-
-# Get just a specific value using dotted notation.
-client.get_config('location.horizon')
-# 30.0
-
-# Set a new value.
-client.set_config('location.horizon', 45)
-# {'location.horizon': 45.0}
-
-# Retrieve the updated value.
-client.get_config('location.horizon')
-# 45.0
-
-# Astropy Quantity values are supported.
-from astropy import units as u
-client.set_config('location.horizon', 45 * u.deg)
-# {'location.horizon': <Quantity 45. deg>}
-
-client.get_config('location.horizon')
-# <Quantity 45. deg>
-
-# Access nested list elements.
-client.get_config('cameras.devices[1].model')
-# 'canon_gphoto2'
-```
-
-### Command-line
-
-`panoptes-utils config get` fetches a key (or the entire config when no key is given) and prints it to the console.
-
-`panoptes-utils config set` updates a key with a new value.
-
-```bash
-$ panoptes-utils config get location
-{'elevation': 3400.0, 'flat_horizon': -6.0, ...}
-
-$ panoptes-utils config get location.horizon
-30.0
-
-$ panoptes-utils config set location.horizon '37 deg'
-{'location.horizon': <Quantity 37. deg>}
-
-# Return entire config (no key argument)
-$ panoptes-utils config get
-```
-
-See `panoptes-utils config get --help` and `panoptes-utils config set --help` for full option details.
-
-## Environment variables
-
-The following environment variables are recognised by the CLI and the Python client:
-
-| Variable | Description | Default |
-| -------- | ----------- | ------- |
-| `PANOPTES_CONFIG_HOST` | Config server host address | `localhost` |
-| `PANOPTES_CONFIG_PORT` | Config server port | `6563` |
-| `PANOPTES_CONFIG_FILE` | YAML config file to load (CLI only) | — |

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,8 +5,8 @@ The file is human-editable and is the only place a user needs to look when setti
 or adjusting their unit.
 
 This page covers the **file-based** configuration helpers provided by `panoptes-utils`:
-typed Pydantic models and a file watcher.  For the legacy HTTP config server, see
-[Config Server](config-server.md).
+typed Pydantic models and a file watcher.  For the deprecated HTTP config server, see
+[Config Server (Deprecated)](config-server.md).
 
 ---
 

--- a/docs/database-to-telemetry.md
+++ b/docs/database-to-telemetry.md
@@ -268,7 +268,7 @@ Each line in an NDJSON file:
 
 Yes, the server must be running for client calls to succeed. It is a lightweight
 uvicorn process with negligible CPU and memory overhead. Start it at system boot
-alongside the config server.
+alongside your main observatory process.
 
 **What happens if I call `post_event()` when the server is not running?**
 
@@ -281,8 +281,8 @@ The server does not expose historical queries — it only serves the current
 in-memory snapshot. For historical analysis, parse the NDJSON files directly
 with `jq`, `pandas`, `DuckDB`, or any NDJSON-aware tool.
 
-**Does the telemetry server replace the config server?**
+**Does the telemetry server replace the config store?**
 
-No. The config server (`panoptes-utils config run`) manages configuration
-key-value state and is still the right place for settings. The telemetry server
+No. The config store (`panoptes.utils.config.store`) manages configuration
+key-value state and is the right place for settings. The telemetry server
 is for time-series observational data.

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,31 +72,27 @@ panoptes-utils image cr2 to-fits <file.cr2>
 panoptes-utils image fits solve <file.fits>
 ```
 
-### `config` — Configuration server
+### `config` — Configuration store
 
-Requires the `config` extra (`pip install "panoptes-utils[config]"`).
-
-Start a local key-value configuration server backed by a YAML file:
+Read and write configuration values from the YAML config file. No server process required.
 
 ```bash
-# Start the server
-panoptes-utils config run --config-file <path-to-file.yaml>
+# Initialise the config file from the built-in template
+panoptes-utils config init
 
 # Read a value (returns entire config if no key given)
 panoptes-utils config get location.elevation
 
 # Update a value
 panoptes-utils config set name "My Observatory"
-
-# Stop the server
-panoptes-utils config stop
 ```
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `PANOPTES_CONFIG_HOST` | Config server host address | `localhost` |
-| `PANOPTES_CONFIG_PORT` | Config server port | `6563` |
-| `PANOPTES_CONFIG_FILE` | YAML config file to load (CLI only) | — |
+| `PANOPTES_CONFIG_FILE` | Path to the YAML config file | `~/.panoptes/config.yaml` |
+
+> **Deprecated:** `panoptes-utils config run` / `config stop` (HTTP server) are deprecated.
+> Use `$PANOPTES_CONFIG_FILE` and the store directly instead.
 
 ### `telemetry` — Telemetry server
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,7 @@ nav:
   - Home: index.md
   - CLI Reference: cli.md
   - Configuration: config.md
-  - Config Server: config-server.md
+  - Config Server (Deprecated): config-server.md
   - Telemetry Server: telemetry.md
   - Database → Telemetry Migration: database-to-telemetry.md
   - API Reference: api.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ config-server = [
     "scalpl",
     "uvicorn>=0.34",
 ]
+config = [
+    "panoptes-utils[config-server]",
+]
 docs = [
     "mkdocs-material",
     "mkdocstrings[python]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,6 @@ config-server = [
     "scalpl",
     "uvicorn>=0.34",
 ]
-# Keep 'config' as a compatibility alias so existing installs don't break.
-config = [
-    "panoptes-utils[config-server]",
-]
 docs = [
     "mkdocs-material",
     "mkdocstrings[python]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,17 @@ Documentation = "https://panoptes.github.io/panoptes-utils/"
 Forum = "https://forum.projectpanoptes.org"
 
 [project.optional-dependencies]
-config = [
+# config-server: deps for the deprecated HTTP config server/client only.
+# The file-based config store (panoptes.utils.config.store) requires no extras.
+config-server = [
     "fastapi>=0.115",
     "PyYAML",
-    "requests",
     "scalpl",
     "uvicorn>=0.34",
+]
+# Keep 'config' as a compatibility alias so existing installs don't break.
+config = [
+    "panoptes-utils[config-server]",
 ]
 docs = [
     "mkdocs-material",

--- a/src/panoptes/utils/cli/config.py
+++ b/src/panoptes/utils/cli/config.py
@@ -1,8 +1,9 @@
-"""Typer commands for the config server."""
+"""Typer commands for config management."""
 
 from __future__ import annotations
 
 import time
+import warnings
 from importlib.resources import as_file, files
 from pathlib import Path
 
@@ -11,7 +12,8 @@ from loguru import logger
 from rich import print
 
 from panoptes.utils.config import DEFAULT_CONFIG_PATH
-from panoptes.utils.config.client import get_config, server_is_running, set_config
+from panoptes.utils.config.helpers import save_config
+from panoptes.utils.config.store import get_config, init_config, set_config
 
 app = typer.Typer()
 
@@ -47,9 +49,6 @@ def config_init(
         # Merge an existing override file
         panoptes-utils config init --from pocs_local.yaml
 
-        # Auto-detect *_local.yaml in the current directory and merge
-        panoptes-utils config init
-
         # Write to a custom path
         panoptes-utils config init --output /etc/panoptes/config.yaml
     """
@@ -65,15 +64,11 @@ def config_init(
         )
         raise typer.Exit(code=1)
 
-    # Load template as the base.
-    # Use as_file() to materialise a real filesystem path, which is necessary in
-    # zipped/wheel installs where Traversable resources are not real file paths.
     template_ref = files("panoptes.utils.config").joinpath("default_config.yaml")
     base_config: dict = {}
     with as_file(template_ref) as template_path:
         _add_to_conf(base_config, template_path, parse=False)
 
-    # Resolve the override source.
     override_path: Path | None = None
     if merge_from:
         override_path = Path(merge_from)
@@ -81,7 +76,6 @@ def config_init(
             print(f"[red]Override file not found:[/red] {override_path}")
             raise typer.Exit(code=1)
     else:
-        # Auto-detect *_local.yaml in the current directory.
         candidates = sorted(Path.cwd().glob("*_local.yaml"))
         if len(candidates) == 1:
             override_path = candidates[0]
@@ -94,7 +88,6 @@ def config_init(
             )
             raise typer.Exit(code=1)
 
-    # Merge overrides on top of the template.
     final_config = base_config
     if override_path:
         overrides: dict = {}
@@ -103,7 +96,6 @@ def config_init(
         merged_keys = sorted(overrides.keys())
         print(f"[dim]Merged keys from {override_path.name}:[/dim] {', '.join(merged_keys)}")
 
-    # Write the result.
     dest.parent.mkdir(parents=True, exist_ok=True)
     from panoptes.utils.serializers import to_yaml
 
@@ -120,17 +112,17 @@ def run(
     host: str = typer.Option(
         None,
         envvar="PANOPTES_CONFIG_HOST",
-        help="Host address to bind the config server to.",
+        help="[Deprecated] Host address to bind the config server to.",
     ),
     port: int = typer.Option(
         6563,
         envvar="PANOPTES_CONFIG_PORT",
-        help="Port number to bind the config server to.",
+        help="[Deprecated] Port number to bind the config server to.",
     ),
     config_file: str = typer.Option(
         None,
         envvar="PANOPTES_CONFIG_FILE",
-        help="Path to the YAML config file to load.",
+        help="[Deprecated] Path to the YAML config file to load.",
     ),
     load_local: bool = typer.Option(True, help="Load local config files on startup."),
     save_local: bool = typer.Option(True, help="Save config changes to the local file."),
@@ -140,7 +132,23 @@ def run(
         help="Seconds to wait for the config server to become ready before giving up.",
     ),
 ) -> None:
-    """Run the config server and block until it stops."""
+    """[Deprecated] Run the HTTP config server.
+
+    The HTTP config server is deprecated. Config is now loaded directly from
+    file via ``panoptes.utils.config.store``. This command will be removed in
+    a future release.
+    """
+    warnings.warn(
+        "The HTTP config server (`panoptes-utils config run`) is deprecated and will be "
+        "removed in a future release. Config is now loaded directly from the YAML file via "
+        "panoptes.utils.config.store. See the migration guide for details.",
+        DeprecationWarning,
+        stacklevel=1,
+    )
+    print(
+        "[yellow]Warning:[/yellow] The HTTP config server is deprecated. "
+        "Config is now loaded from file directly via the config store."
+    )
 
     try:
         from panoptes.utils.config import server
@@ -176,6 +184,8 @@ def run(
             f"Waiting for readiness on {client_host}:{port}"
         )
 
+        from panoptes.utils.config.client import server_is_running
+
         startup_elapsed = 0.0
         startup_interval = 0.5
         while startup_elapsed < startup_timeout:
@@ -202,11 +212,9 @@ def run(
             server_process.terminate()
             server_process.join(30)
     finally:
-        # Ensure the server process is always reaped to avoid zombies.
         if server_process.is_alive():
             logger.info(f"Config server process {server_process.pid} still running at shutdown, terminating")
             server_process.terminate()
-        # A second join after earlier joins is safe and ensures the process handle is cleaned up.
         server_process.join(30)
 
 
@@ -215,18 +223,28 @@ def stop(
     host: str = typer.Option(
         "localhost",
         envvar="PANOPTES_CONFIG_HOST",
-        help="Host address of the config server.",
+        help="[Deprecated] Host address of the config server.",
     ),
     port: int = typer.Option(
         6563,
         envvar="PANOPTES_CONFIG_PORT",
-        help="Port number of the config server.",
+        help="[Deprecated] Port number of the config server.",
     ),
 ) -> None:
-    """Stop the config server."""
+    """[Deprecated] Stop the HTTP config server.
 
-    logger.info(f"Shutting down config server on {host}:{port}")
-    set_config("config_server.running", False, host=host, port=port)
+    The HTTP config server is deprecated. This command will be removed in a
+    future release.
+    """
+    warnings.warn(
+        "The HTTP config server (`panoptes-utils config stop`) is deprecated.",
+        DeprecationWarning,
+        stacklevel=1,
+    )
+    print("[yellow]Warning:[/yellow] The HTTP config server is deprecated.")
+    from panoptes.utils.config.client import set_config as _http_set_config
+
+    _http_set_config("config_server.running", False, host=host, port=port)
 
 
 @app.command("get")
@@ -235,33 +253,28 @@ def config_getter(
         None,
         help="Dotted key to retrieve (e.g. 'location.elevation'). Returns entire config if omitted.",
     ),
-    host: str = typer.Option(
-        "localhost",
-        envvar="PANOPTES_CONFIG_HOST",
-        help="Host address of the config server.",
-    ),
-    port: int = typer.Option(
-        6563,
-        envvar="PANOPTES_CONFIG_PORT",
-        help="Port number of the config server.",
+    config_file: Path | None = typer.Option(
+        None,
+        envvar="PANOPTES_CONFIG_FILE",
+        help="Path to the YAML config file. Defaults to $PANOPTES_CONFIG_FILE or ~/.panoptes/config.yaml.",
     ),
     default: str | None = typer.Option(None, help="Default value to return if key is not found."),
-    parse: bool = typer.Option(True, help="Parse result into a Python object."),
 ) -> None:
     """Get a config value by dotted key name (e.g. 'location.elevation').
 
+    Reads directly from the config file — no server required.
     Returns the entire config if no key is given.
     """
-
+    init_config(config_file)
     logger.debug(f"Getting config key={key!r}")
     try:
-        config_entry = get_config(key=key, host=host, port=port, parse=parse, default=default)
+        config_entry = get_config(key=key, default=default)
     except Exception as e:
         logger.error(f"Error while trying to get config: {e!r}")
         print(f"[red]Error while trying to get config: {e!r}[/red]")
         raise typer.Exit(code=1)
 
-    logger.debug(f"Config server response: config_entry={config_entry!r}")
+    logger.debug(f"Config value: config_entry={config_entry!r}")
     print(config_entry)
 
 
@@ -269,23 +282,24 @@ def config_getter(
 def config_setter(
     key: str = typer.Argument(..., help="Dotted key to update (e.g. 'location.elevation')."),
     new_value: str = typer.Argument(..., help="New value to assign."),
-    host: str = typer.Option(
-        "localhost",
-        envvar="PANOPTES_CONFIG_HOST",
-        help="Host address of the config server.",
+    config_file: Path | None = typer.Option(
+        None,
+        envvar="PANOPTES_CONFIG_FILE",
+        help="Path to the YAML config file. Defaults to $PANOPTES_CONFIG_FILE or ~/.panoptes/config.yaml.",
     ),
-    port: int = typer.Option(
-        6563,
-        envvar="PANOPTES_CONFIG_PORT",
-        help="Port number of the config server.",
-    ),
-    parse: bool = typer.Option(True, help="Parse the new value into a Python object."),
+    persist: bool = typer.Option(True, help="Write the updated config back to the file."),
 ) -> None:
-    """Set a config value by dotted key name (e.g. 'location.elevation')."""
+    """Set a config value by dotted key name and save to file.
 
-    logger.debug(f"Setting config key={key!r} new_value={new_value!r} on {host}:{port}")
-    config_entry = set_config(key, new_value, host=host, port=port, parse=parse)
-    print(config_entry)
+    Updates the config in memory and writes the result back to the config file.
+    """
+    init_config(config_file)
+    logger.debug(f"Setting config key={key!r} new_value={new_value!r}")
+    set_config(key, new_value)
+    if persist:
+        save_config(config_file, get_config())
+        logger.debug(f"Config saved to {config_file or 'default path'}")
+    print(f"Set [bold]{key}[/bold] = {new_value!r}")
 
 
 if __name__ == "__main__":

--- a/src/panoptes/utils/cli/config.py
+++ b/src/panoptes/utils/cli/config.py
@@ -12,7 +12,6 @@ from loguru import logger
 from rich import print
 
 from panoptes.utils.config import DEFAULT_CONFIG_PATH
-from panoptes.utils.config.helpers import save_config
 from panoptes.utils.config.store import get_config, init_config, set_config
 
 app = typer.Typer()
@@ -295,9 +294,8 @@ def config_setter(
     """
     init_config(config_file)
     logger.debug(f"Setting config key={key!r} new_value={new_value!r}")
-    set_config(key, new_value)
+    set_config(key, new_value, persist=persist)
     if persist:
-        save_config(config_file, get_config())
         logger.debug(f"Config saved to {config_file or 'default path'}")
     print(f"Set [bold]{key}[/bold] = {new_value!r}")
 

--- a/src/panoptes/utils/cli/main.py
+++ b/src/panoptes/utils/cli/main.py
@@ -8,7 +8,6 @@ from panoptes.utils.cli import image
 
 try:
     from panoptes.utils.cli import config as config_cli
-    from panoptes.utils.config import server as _config_server  # noqa: F401  # requires "config" extra
 except ImportError:
     config_cli = None
 

--- a/src/panoptes/utils/config/__init__.py
+++ b/src/panoptes/utils/config/__init__.py
@@ -1,5 +1,6 @@
 from panoptes.utils.config.helpers import DEFAULT_CONFIG_PATH, deep_merge, load_config, save_config
 from panoptes.utils.config.models import DatabaseConfig, DirectoriesConfig, LocationConfig, UnitConfig
+from panoptes.utils.config.store import get_config, init_config, reload_config, set_config
 from panoptes.utils.config.watcher import ConfigWatcher
 
 __all__ = [
@@ -12,4 +13,8 @@ __all__ = [
     "LocationConfig",
     "UnitConfig",
     "ConfigWatcher",
+    "get_config",
+    "init_config",
+    "reload_config",
+    "set_config",
 ]

--- a/src/panoptes/utils/config/client.py
+++ b/src/panoptes/utils/config/client.py
@@ -1,4 +1,21 @@
+"""HTTP config client — deprecated.
+
+The HTTP config server/client is deprecated in favour of
+:mod:`panoptes.utils.config.store`, which loads config directly from the YAML
+file without requiring a running server process.  This module will be removed
+in a future release.
+
+Migration::
+
+    # Old
+    from panoptes.utils.config.client import get_config, set_config
+
+    # New
+    from panoptes.utils.config.store import get_config, set_config
+"""
+
 import os
+import warnings
 
 import requests
 from loguru import logger
@@ -6,6 +23,13 @@ from requests.exceptions import ConnectionError
 
 from panoptes.utils.error import InvalidConfig
 from panoptes.utils.serializers import from_json, to_json
+
+warnings.warn(
+    "panoptes.utils.config.client is deprecated and will be removed in a future release. "
+    "Use panoptes.utils.config.store instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 def server_is_running(*args, **kwargs):  # pragma: no cover
@@ -31,34 +55,34 @@ def get_config(
 
     .. doctest::
 
-        >>> get_config(key='name')
+        >>> get_config(key='name')  # doctest: +SKIP
         'Testing PANOPTES Unit'
 
-        >>> get_config(key='location.horizon')
+        >>> get_config(key='location.horizon')  # doctest: +SKIP
         <Quantity 30. deg>
 
         >>> # With no parsing, the raw string (including quotes) is returned.
-        >>> get_config(key='location.horizon', parse=False)
+        >>> get_config(key='location.horizon', parse=False)  # doctest: +SKIP
         '"30 deg"'
-        >>> get_config(key='cameras.devices[1].model')
+        >>> get_config(key='cameras.devices[1].model')  # doctest: +SKIP
         'canon_gphoto2'
 
         >>> # Returns `None` if key is not found.
-        >>> foobar = get_config(key='foobar')
-        >>> foobar is None
+        >>> foobar = get_config(key='foobar')  # doctest: +SKIP
+        >>> foobar is None  # doctest: +SKIP
         True
 
         >>> # But you can supply a default.
-        >>> get_config(key='foobar', default='baz')
+        >>> get_config(key='foobar', default='baz')  # doctest: +SKIP
         'baz'
 
         >>> # key and default are first two parameters.
-        >>> get_config('foobar', 'baz')
+        >>> get_config('foobar', 'baz')  # doctest: +SKIP
         'baz'
 
         >>> # Can use Quantities as well.
-        >>> from astropy import units as u
-        >>> get_config('foobar', 42 * u.meter)
+        >>> from astropy import units as u  # doctest: +SKIP
+        >>> get_config('foobar', 42 * u.meter)  # doctest: +SKIP
         <Quantity 42. m>
 
 
@@ -137,17 +161,17 @@ def set_config(key, new_value, host=None, port=None, parse=True):
 
     .. doctest::
 
-        >>> from astropy import units as u
+        >>> from astropy import units as u  # doctest: +SKIP
 
         >>> # Can use astropy units.
-        >>> set_config('location.horizon', 35 * u.degree)
+        >>> set_config('location.horizon', 35 * u.degree)  # doctest: +SKIP
         {'location.horizon': <Quantity 35. deg>}
 
-        >>> get_config(key='location.horizon')
+        >>> get_config(key='location.horizon')  # doctest: +SKIP
         <Quantity 35. deg>
 
         >>> # String equivalent works for 'deg', 'm', 's'.
-        >>> set_config('location.horizon', '30 deg')
+        >>> set_config('location.horizon', '30 deg')  # doctest: +SKIP
         {'location.horizon': <Quantity 30. deg>}
 
     Args:

--- a/src/panoptes/utils/config/helpers.py
+++ b/src/panoptes/utils/config/helpers.py
@@ -21,9 +21,6 @@ def load_config[M: BaseModel](
 ) -> dict | M:
     """Loads configuration information from one or more YAML files.
 
-    This function is used by the config server; normal config usage should
-    be via a running config server.
-
     If ``config_files`` is ``None``, the path is resolved in this order:
 
     1. The ``$PANOPTES_CONFIG_FILE`` environment variable (if set).

--- a/src/panoptes/utils/config/server.py
+++ b/src/panoptes/utils/config/server.py
@@ -1,5 +1,24 @@
+"""HTTP config server — deprecated.
+
+The HTTP config server is deprecated in favour of
+:mod:`panoptes.utils.config.store`, which loads config directly from the YAML
+file without requiring a running server process.  This module will be removed
+in a future release.
+
+Migration::
+
+    # Old: start a server in conftest.py / startup code
+    from panoptes.utils.config.server import config_server
+    config_server("path/to/config.yaml", port=6563)
+
+    # New: initialise the in-process store once
+    from panoptes.utils.config.store import init_config
+    init_config("path/to/config.yaml")
+"""
+
 import logging
 import os
+import warnings
 from multiprocessing import Process
 from sys import platform
 
@@ -11,6 +30,13 @@ from ruamel.yaml.parser import ParserError
 from scalpl import Cut
 
 from panoptes.utils.config.helpers import load_config, save_config
+
+warnings.warn(
+    "panoptes.utils.config.server is deprecated and will be removed in a future release. "
+    "Use panoptes.utils.config.store instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 # Platform-specific multiprocessing setup.
 if platform == "darwin" or platform == "win32":

--- a/src/panoptes/utils/config/store.py
+++ b/src/panoptes/utils/config/store.py
@@ -1,0 +1,176 @@
+"""Module-level in-memory config store for PANOPTES.
+
+Provides :func:`get_config` and :func:`set_config` as a lightweight alternative to
+the HTTP config server.  Config is loaded from a YAML file once at startup (or on
+demand) and held in a process-level dict.
+
+This is the preferred approach for any PANOPTES component that does not need to
+share live config updates over the network.  For cross-process config broadcasting
+see :mod:`panoptes.utils.config.server` and :mod:`panoptes.utils.config.watcher`.
+
+Typical usage::
+
+    from panoptes.utils.config.store import get_config, set_config, init_config
+
+    init_config("~/.panoptes/config.yaml")
+
+    lat = get_config("location.latitude")
+    set_config("location.horizon", "30 deg")
+    cameras = get_config("cameras.devices[0].model")
+
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from panoptes.utils.config.helpers import load_config as _load_config_file
+
+_CONFIG: dict[str, Any] = {}
+_CONFIG_FILE: Path | None = None
+
+
+def _get_nested(d: dict[str, Any], key: str, default: Any = None) -> Any:
+    """Navigate a nested dict using dotted-key notation.
+
+    Supports list-index syntax, e.g. ``"cameras.devices[0].model"``.
+
+    Args:
+        d: The dict to navigate.
+        key: Dotted key, optionally with ``[N]`` list-index suffixes.
+        default: Value returned when the key path is not found.
+
+    Returns:
+        The value at ``key``, or *default* if any step of the path is missing.
+    """
+    if not key:
+        return d
+
+    current: Any = d
+    for part in key.split("."):
+        if not isinstance(current, dict):
+            return default
+
+        if match := re.fullmatch(r"([^\[\]]+)(\[(-?\d+)\])?", part):
+            name = match.group(1)
+            index = match.group(3)
+        else:  # pragma: no cover — every non-empty string matches
+            name = part
+            index = None
+
+        if name not in current:
+            return default
+
+        current = current[name]
+
+        if index is not None:
+            if not isinstance(current, list):
+                return default
+            try:
+                current = current[int(index)]
+            except (IndexError, ValueError):
+                return default
+
+    return current
+
+
+def _set_nested(d: dict[str, Any], keys: list[str], value: Any) -> None:
+    """Set a leaf value in a nested dict, creating intermediate dicts as needed.
+
+    Args:
+        d: The top-level dict to update (mutated in-place).
+        keys: Key path as a list of strings (result of ``key.split(".")``)
+        value: The value to store at the leaf.
+    """
+    for key in keys[:-1]:
+        if key not in d or not isinstance(d[key], dict):
+            d[key] = {}
+        d = d[key]
+    d[keys[-1]] = value
+
+
+def init_config(config_file: str | Path | None = None) -> dict[str, Any]:
+    """Load config from a YAML file and initialise the module-level store.
+
+    If *config_file* is ``None`` the path is resolved by
+    :func:`panoptes.utils.config.helpers.load_config` in the following order:
+
+    1. The ``$PANOPTES_CONFIG_FILE`` environment variable (if set).
+    2. ``~/.panoptes/config.yaml``.
+
+    Args:
+        config_file: Path to a YAML config file. Passing ``None`` re-uses the
+            previously configured path (or falls back to env-var / default).
+
+    Returns:
+        The loaded config dict.
+    """
+    global _CONFIG, _CONFIG_FILE
+    if config_file is not None:
+        _CONFIG_FILE = Path(config_file).expanduser()
+    _CONFIG = _load_config_file(_CONFIG_FILE, load_local=False)
+    logger.debug(f"Config initialised from {_CONFIG_FILE!r}")
+    return _CONFIG
+
+
+def reload_config() -> dict[str, Any]:
+    """Reload config from the same file used by :func:`init_config`.
+
+    Returns:
+        The refreshed config dict.
+    """
+    return init_config(_CONFIG_FILE)
+
+
+def get_config(key: str | None = None, default: Any = None, **kwargs) -> Any:
+    """Get a config value by dotted-key name.
+
+    If the store has not been initialised yet, :func:`init_config` is called
+    automatically using the default file resolution.
+
+    Args:
+        key: Dotted key, e.g. ``"location.latitude"`` or
+            ``"cameras.devices[0].model"``. Pass ``None`` (the default) to
+            return the entire config dict.
+        default: Value to return when *key* is not found.
+        **kwargs: Accepted but ignored — present for drop-in compatibility with
+            the old HTTP config-client signature.
+
+    Returns:
+        The config value, or *default* if *key* is not found.
+    """
+    del kwargs
+    if not _CONFIG:
+        init_config()
+    if key is None:
+        return _CONFIG
+    value = _get_nested(_CONFIG, key, default)
+    logger.trace(f"get_config {key!r} -> {value!r}")
+    return value
+
+
+def set_config(key: str, new_value: Any, **kwargs) -> Any:
+    """Set a config value by dotted-key name (in-memory only).
+
+    Updates the in-memory store.  Changes are **not** written to disk
+    automatically; call :func:`panoptes.utils.config.helpers.save_config` to
+    persist them.
+
+    Args:
+        key: Dotted key, e.g. ``"location.latitude"``.
+        new_value: The value to store.
+        **kwargs: Accepted but ignored — present for drop-in compatibility with
+            the old HTTP config-client signature.
+
+    Returns:
+        *new_value* as stored (mirrors the old HTTP client behaviour).
+    """
+    del kwargs
+    global _CONFIG
+    if not _CONFIG:
+        init_config()
+    _set_nested(_CONFIG, key.split("."), new_value)
+    logger.trace(f"set_config {key!r} = {new_value!r}")
+    return new_value

--- a/src/panoptes/utils/config/store.py
+++ b/src/panoptes/utils/config/store.py
@@ -82,14 +82,46 @@ def _set_nested(d: dict[str, Any], keys: list[str], value: Any) -> None:
 
     Args:
         d: The top-level dict to update (mutated in-place).
-        keys: Key path as a list of strings (result of ``key.split(".")``)
+        keys: Key path as a list of dotted-key segments.
         value: The value to store at the leaf.
     """
-    for key in keys[:-1]:
-        if key not in d or not isinstance(d[key], dict):
-            d[key] = {}
-        d = d[key]
-    d[keys[-1]] = value
+    current: Any = d
+    for i, part in enumerate(keys):
+        if match := re.fullmatch(r"([^\[\]]+)(\[(-?\d+)\])?", part):
+            name = match.group(1)
+            index = match.group(3)
+        else:  # pragma: no cover — every non-empty string matches
+            name = part
+            index = None
+
+        is_last = i == len(keys) - 1
+        if index is None:
+            if not isinstance(current, dict):
+                raise TypeError(f"Cannot set key {part!r} on non-dict path segment")
+            if is_last:
+                current[name] = value
+                return
+            if name not in current or not isinstance(current[name], dict):
+                current[name] = {}
+            current = current[name]
+            continue
+
+        if not isinstance(current, dict):
+            raise TypeError(f"Cannot index key {name!r} on non-dict path segment")
+        if name not in current or not isinstance(current[name], list):
+            current[name] = []
+        values = current[name]
+        idx = int(index)
+        if idx < 0:
+            raise IndexError("Negative list indices are not supported for set_config")
+        while len(values) <= idx:
+            values.append({})
+        if is_last:
+            values[idx] = value
+            return
+        if not isinstance(values[idx], dict):
+            values[idx] = {}
+        current = values[idx]
 
 
 def init_config(config_file: str | Path | None = None) -> dict[str, Any]:
@@ -168,7 +200,8 @@ def set_config(key: str, new_value: Any, persist: bool = True, **kwargs) -> Any:
             the old HTTP config-client signature.
 
     Returns:
-        *new_value* as stored (mirrors the old HTTP client behaviour).
+        *new_value* as stored. Unlike the deprecated HTTP client this does not
+        return ``{key: value}``.
     """
     del kwargs
     global _CONFIG

--- a/src/panoptes/utils/config/store.py
+++ b/src/panoptes/utils/config/store.py
@@ -27,6 +27,7 @@ from typing import Any
 from loguru import logger
 
 from panoptes.utils.config.helpers import load_config as _load_config_file
+from panoptes.utils.config.helpers import save_config as _save_config
 
 _CONFIG: dict[str, Any] = {}
 _CONFIG_FILE: Path | None = None
@@ -151,16 +152,18 @@ def get_config(key: str | None = None, default: Any = None, **kwargs) -> Any:
     return value
 
 
-def set_config(key: str, new_value: Any, **kwargs) -> Any:
-    """Set a config value by dotted-key name (in-memory only).
+def set_config(key: str, new_value: Any, persist: bool = True, **kwargs) -> Any:
+    """Set a config value by dotted-key name.
 
-    Updates the in-memory store.  Changes are **not** written to disk
-    automatically; call :func:`panoptes.utils.config.helpers.save_config` to
-    persist them.
+    Updates the in-memory store. When *persist* is ``True`` (the default) the
+    change is also written back to the config file that was passed to
+    :func:`init_config`, preserving backward compatibility with the old HTTP
+    client which persisted changes to the server by default.
 
     Args:
         key: Dotted key, e.g. ``"location.latitude"``.
         new_value: The value to store.
+        persist: Write the updated config back to disk. Defaults to ``True``.
         **kwargs: Accepted but ignored — present for drop-in compatibility with
             the old HTTP config-client signature.
 
@@ -173,4 +176,7 @@ def set_config(key: str, new_value: Any, **kwargs) -> Any:
         init_config()
     _set_nested(_CONFIG, key.split("."), new_value)
     logger.trace(f"set_config {key!r} = {new_value!r}")
+    if persist:
+        _save_config(_CONFIG_FILE, _CONFIG)
+        logger.trace(f"set_config persisted to {_CONFIG_FILE!r}")
     return new_value

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -1,0 +1,15 @@
+"""Fixtures for config tests."""
+
+import pytest
+
+import panoptes.utils.config.store as _store_mod
+
+
+@pytest.fixture(autouse=True)
+def reset_config_store(config_path):
+    """Reset the in-memory config store to a clean state after each test.
+
+    This prevents test pollution when a test calls set_config().
+    """
+    yield
+    _store_mod.init_config(config_path)

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -1,15 +1,27 @@
 """Fixtures for config tests."""
 
+import shutil
+
 import pytest
 
 import panoptes.utils.config.store as _store_mod
 
 
+@pytest.fixture()
+def config_path(tmp_path):
+    """Return a per-test writable copy of tests/testing.yaml.
+
+    Overrides the session-scoped fixture from the root conftest so that
+    set_config(persist=True) writes don't contaminate other tests.
+    """
+    src = "tests/testing.yaml"
+    dest = tmp_path / "testing.yaml"
+    shutil.copy(src, dest)
+    return dest
+
+
 @pytest.fixture(autouse=True)
 def reset_config_store(config_path):
-    """Reset the in-memory config store to a clean state after each test.
-
-    This prevents test pollution when a test calls set_config().
-    """
+    """Reset the in-memory config store to a clean state after each test."""
     yield
     _store_mod.init_config(config_path)

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -22,6 +22,6 @@ def config_path(tmp_path):
 
 @pytest.fixture(autouse=True)
 def reset_config_store(config_path):
-    """Reset the in-memory config store to a clean state after each test."""
-    yield
+    """Reset the in-memory config store to a clean state for each test."""
     _store_mod.init_config(config_path)
+    yield

--- a/tests/config/test_config_cli.py
+++ b/tests/config/test_config_cli.py
@@ -1,7 +1,3 @@
-import sys
-import time
-from multiprocessing import Process
-
 import pytest
 from typer.testing import CliRunner
 
@@ -13,65 +9,71 @@ def runner():
     return CliRunner()
 
 
-@pytest.fixture(scope="module")
-def cli_config_port():
-    return 12345
-
-
-@pytest.mark.skipif(sys.platform == "darwin", reason="forking CliRunner on macOS causes fatal abort")
-def test_cli_server(runner, config_path, cli_config_port):
-    def run_cli():
-        result = runner.invoke(
-            app,
-            [
-                "run",
-                "--config-file",
-                f"{config_path}",
-                "--port",
-                str(cli_config_port),
-                "--no-save-local",
-                "--no-load-local",
-            ],
-        )
-        assert result.exit_code == 0
-
-    proc = Process(target=run_cli)
-    proc.start()
-    assert proc.pid
-
-    # Let the server start.
-    time.sleep(5)
-
-    try:
-        result = runner.invoke(
-            app,
-            [
-                "get",
-                "name",
-                "--port",
-                str(cli_config_port),
-            ],
-        )
-        assert result.exit_code == 0
-        assert "Testing PANOPTES Unit" in result.stdout
-    finally:
-        proc.terminate()
-        proc.join(30)
-
-
-def test_config_server_cli(runner):
-    # Use the default port (8765) from conftest.py
-    cli_config_port = 8765
-    result = runner.invoke(app, ["get", "name", "--port", str(cli_config_port)])
-    assert result.exit_code == 0
+def test_config_cli_get(runner, config_path, tmp_path):
+    """get command reads from the config file."""
+    result = runner.invoke(app, ["get", "name", "--config-file", str(config_path)])
+    assert result.exit_code == 0, result.output
     assert "Testing PANOPTES Unit" in result.stdout
 
-    # Set the name.
-    result = runner.invoke(app, ["set", "name", "foobar", "--port", str(cli_config_port)])
-    assert result.exit_code == 0
-    assert "foobar" in result.stdout
 
-    # Get the name back.
-    result = runner.invoke(app, ["get", "name", "--port", str(cli_config_port)])
-    assert result.exit_code == 0
-    assert "foobar" in result.stdout
+def test_config_cli_get_dotted_key(runner, config_path):
+    """get command supports dotted-key notation."""
+    result = runner.invoke(app, ["get", "location.horizon", "--config-file", str(config_path)])
+    assert result.exit_code == 0, result.output
+    assert "30" in result.stdout
+
+
+def test_config_cli_get_missing_key_returns_default(runner, config_path):
+    """get command returns the default when key is not found."""
+    result = runner.invoke(
+        app, ["get", "nonexistent.key", "--config-file", str(config_path), "--default", "42"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "42" in result.stdout
+
+
+def test_config_cli_get_no_key_returns_full_config(runner, config_path):
+    """get with no key returns the full config dict."""
+    result = runner.invoke(app, ["get", "--config-file", str(config_path)])
+    assert result.exit_code == 0, result.output
+    assert "Testing PANOPTES Unit" in result.stdout
+
+
+def test_config_cli_set_and_get(runner, tmp_path, config_path):
+    """set command updates the value and saves it to a temp file."""
+    from panoptes.utils.config.helpers import load_config
+    from panoptes.utils.serializers import to_yaml
+
+    # Make a mutable copy of the test config in tmp_path.
+    original = load_config(config_path, load_local=False)
+    temp_config = tmp_path / "config.yaml"
+    with temp_config.open("w") as fh:
+        to_yaml(original, stream=fh)
+
+    result = runner.invoke(app, ["set", "name", "My Test Unit", "--config-file", str(temp_config)])
+    assert result.exit_code == 0, result.output
+    assert "My Test Unit" in result.stdout
+
+    # Verify the file was updated.
+    updated = load_config(temp_config, load_local=False)
+    assert updated["name"] == "My Test Unit"
+
+
+def test_config_cli_set_no_persist(runner, tmp_path, config_path):
+    """set --no-persist updates in memory but does not touch the file."""
+    from panoptes.utils.config.helpers import load_config
+    from panoptes.utils.serializers import to_yaml
+
+    original = load_config(config_path, load_local=False)
+    temp_config = tmp_path / "config.yaml"
+    with temp_config.open("w") as fh:
+        to_yaml(original, stream=fh)
+
+    result = runner.invoke(
+        app, ["set", "name", "In Memory Only", "--config-file", str(temp_config), "--no-persist"]
+    )
+    assert result.exit_code == 0, result.output
+
+    # File should be unchanged.
+    on_disk = load_config(temp_config, load_local=False)
+    assert on_disk["name"] == original["name"]

--- a/tests/config/test_config_cli.py
+++ b/tests/config/test_config_cli.py
@@ -1,3 +1,6 @@
+import warnings
+from unittest.mock import MagicMock, patch
+
 import pytest
 from typer.testing import CliRunner
 
@@ -39,6 +42,14 @@ def test_config_cli_get_no_key_returns_full_config(runner, config_path):
     assert "Testing PANOPTES Unit" in result.stdout
 
 
+def test_config_cli_get_error_path(runner, config_path):
+    """get command exits with code 1 when get_config raises."""
+    with patch("panoptes.utils.cli.config.get_config", side_effect=RuntimeError("boom")):
+        result = runner.invoke(app, ["get", "any.key", "--config-file", str(config_path)])
+    assert result.exit_code == 1
+    assert "Error" in result.stdout
+
+
 def test_config_cli_set_and_get(runner, tmp_path, config_path):
     """set command updates the value and saves it to a temp file."""
     from panoptes.utils.config.helpers import load_config
@@ -77,3 +88,104 @@ def test_config_cli_set_no_persist(runner, tmp_path, config_path):
     # File should be unchanged.
     on_disk = load_config(temp_config, load_local=False)
     assert on_disk["name"] == original["name"]
+
+
+# --- deprecated run / stop commands ---
+
+
+def test_run_emits_deprecation_and_exits_on_server_error(runner, config_path):
+    """run command emits a DeprecationWarning and exits cleanly when server fails to start."""
+    import sys
+
+    mock_server = MagicMock()
+    mock_server.config_server.side_effect = RuntimeError("no server")
+
+    with patch.dict(sys.modules, {"panoptes.utils.config.server": mock_server}):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = runner.invoke(app, ["run", "--config-file", str(config_path)])
+
+    assert result.exit_code == 1
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_run_exits_when_server_import_fails(runner, config_path):
+    """run command exits with code 1 when server dependencies are not installed."""
+    import sys
+
+    with patch.dict(sys.modules, {"panoptes.utils.config.server": None}):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            result = runner.invoke(app, ["run", "--config-file", str(config_path)])
+
+    assert result.exit_code == 1
+
+
+def test_run_server_starts_and_exits_when_process_dies(runner, config_path):
+    """run command exits normally once the server process stops running."""
+    import sys
+
+    mock_process = MagicMock()
+    mock_process.pid = 99999
+    # Calls: [main-loop-iter1, main-loop-exit, finally-check]
+    mock_process.is_alive.side_effect = [True, False, False]
+
+    mock_server = MagicMock()
+    mock_server.config_server.return_value = mock_process
+
+    mock_client = MagicMock()
+    mock_client.server_is_running.return_value = True
+
+    with patch.dict(
+        sys.modules,
+        {
+            "panoptes.utils.config.server": mock_server,
+            "panoptes.utils.config.client": mock_client,
+        },
+    ):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            result = runner.invoke(app, ["run", "--config-file", str(config_path), "--heartbeat", "0.001"])
+
+    assert result.exit_code == 0
+
+
+def test_stop_emits_deprecation(runner):
+    """stop command emits a DeprecationWarning."""
+    with patch("panoptes.utils.config.client.set_config"):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = runner.invoke(app, ["stop"])
+
+    assert result.exit_code == 0
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+# --- config init command ---
+
+
+def test_config_init_auto_detects_single_local_yaml(runner, tmp_path, monkeypatch):
+    """init command auto-detects a single *_local.yaml in cwd."""
+    monkeypatch.chdir(tmp_path)
+    local_yaml = tmp_path / "pocs_local.yaml"
+    local_yaml.write_text("name: My Unit\n")
+    dest = tmp_path / "config_out.yaml"
+
+    result = runner.invoke(app, ["init", "--output", str(dest)])
+
+    assert result.exit_code == 0, result.output
+    assert "Auto-detected" in result.stdout
+    assert dest.exists()
+
+
+def test_config_init_multiple_local_yaml_exits(runner, tmp_path, monkeypatch):
+    """init command exits with code 1 when multiple *_local.yaml files are found."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "a_local.yaml").write_text("x: 1\n")
+    (tmp_path / "b_local.yaml").write_text("y: 2\n")
+    dest = tmp_path / "config_out.yaml"
+
+    result = runner.invoke(app, ["init", "--output", str(dest)])
+
+    assert result.exit_code == 1
+    assert "Multiple" in result.stdout

--- a/tests/config/test_config_server.py
+++ b/tests/config/test_config_server.py
@@ -1,76 +1,60 @@
-import pytest
-import requests
+"""Tests for panoptes.utils.config.store (in-memory config store)."""
+
 from astropy import units as u
 
-from panoptes.utils import serializers
-from panoptes.utils.config.client import get_config, set_config
+from panoptes.utils.config.store import get_config, init_config, reload_config, set_config
 
 
-@pytest.fixture(scope="module")
-def config_host():
-    return "localhost"
-
-
-@pytest.fixture(scope="module")
-def config_port():
-    return 8765
-
-
-def test_config_client():
+def test_get_config_returns_dict(config_path):
+    init_config(config_path)
     assert isinstance(get_config(), dict)
 
+
+def test_get_config_dotted_key(config_path):
+    init_config(config_path)
     assert get_config("location.horizon") == 30 * u.degree
-    assert set_config("location.horizon", 47 * u.degree) == {"location.horizon": 47 * u.degree}
+
+
+def test_set_config_updates_value(config_path):
+    init_config(config_path)
+    set_config("location.horizon", 47 * u.degree)
     assert get_config("location.horizon") == 47 * u.degree
 
-    # Without parsing the result contains the double-quotes since that's what the raw
-    # response has.
-    assert get_config("location.horizon", parse=False) == '"47.0 deg"'
 
-    assert set_config("location.horizon", 42 * u.degree, parse=False) == {"location.horizon": "42.0 deg"}
-
-
-def test_config_client_bad(caplog):
-    # Bad host will return `None` but also throw error
-    assert set_config("foo", 42, host="foobaz") is None
-    assert caplog.records[-1].levelname == "WARNING"
-    assert caplog.records[-1].message.startswith("Problem with set_config")
-
-    # Bad host will return `None`; with verbose=True the connection error is logged at DEBUG.
-    assert get_config("foo", host="foobaz", verbose=True) is None
-    found_log = False
-    for rec in caplog.records[-5:]:
-        if rec.levelname == "DEBUG" and rec.message.startswith("Bad connection to config-server"):
-            found_log = True
-
-    assert found_log
+def test_set_config_returns_value(config_path):
+    init_config(config_path)
+    result = set_config("location.horizon", 42 * u.degree)
+    assert result == 42 * u.degree
 
 
-def test_config_reset(config_host, config_port):
-    # Reset config via url
-    url = f"http://{config_host}:{config_port}/reset-config"
+def test_get_config_default(config_path):
+    init_config(config_path)
+    assert get_config("nonexistent.key", default="fallback") == "fallback"
+    assert get_config("nonexistent.key") is None
 
-    def reset_conf():
-        response = requests.post(
-            url,
-            data=serializers.to_json({"reset": True}),
-            headers={"Content-Type": "application/json"},
-        )
-        assert response.ok
 
-    reset_conf()
+def test_reload_config_restores_value(config_path):
+    init_config(config_path)
+    original = get_config("location.horizon")
+    set_config("location.horizon", 99 * u.degree)
+    assert get_config("location.horizon") == 99 * u.degree
 
-    # Check we are at default value.
-    assert get_config("location.horizon") == 30 * u.degree
+    reload_config()
+    assert get_config("location.horizon") == original
 
-    # Set to new value.
-    set_config_return = set_config("location.horizon", 3 * u.degree)
-    assert set_config_return == {"location.horizon": 3 * u.degree}
 
-    # Check we have changed.
-    assert get_config("location.horizon") == 3 * u.degree
+def test_get_config_list_index(config_path):
+    init_config(config_path)
+    assert get_config("cameras.devices[1].model") == "canon_gphoto2"
 
-    reset_conf()
 
-    # Check we are at default again.
-    assert get_config("location.horizon") == 30 * u.degree
+def test_get_config_none_key_returns_full_dict(config_path):
+    init_config(config_path)
+    cfg = get_config(None)
+    assert isinstance(cfg, dict)
+    assert "name" in cfg
+
+
+def test_get_name(config_path):
+    init_config(config_path)
+    assert get_config("name") == "Testing PANOPTES Unit"

--- a/tests/config/test_config_server.py
+++ b/tests/config/test_config_server.py
@@ -56,6 +56,12 @@ def test_get_config_list_index(config_path):
     assert get_config("cameras.devices[1].model") == "canon_gphoto2"
 
 
+def test_set_config_list_index(config_path):
+    init_config(config_path)
+    set_config("cameras.devices[0].model", "updated-model", persist=False)
+    assert get_config("cameras.devices[0].model") == "updated-model"
+
+
 def test_get_config_none_key_returns_full_dict(config_path):
     init_config(config_path)
     cfg = get_config(None)

--- a/tests/config/test_config_server.py
+++ b/tests/config/test_config_server.py
@@ -2,7 +2,15 @@
 
 from astropy import units as u
 
-from panoptes.utils.config.store import get_config, init_config, reload_config, set_config
+import panoptes.utils.config.store as _store_mod
+from panoptes.utils.config.store import (
+    _get_nested,
+    _set_nested,
+    get_config,
+    init_config,
+    reload_config,
+    set_config,
+)
 
 
 def test_get_config_returns_dict(config_path):
@@ -58,3 +66,62 @@ def test_get_config_none_key_returns_full_dict(config_path):
 def test_get_name(config_path):
     init_config(config_path)
     assert get_config("name") == "Testing PANOPTES Unit"
+
+
+# --- _get_nested edge cases ---
+
+
+def test_get_nested_empty_key_returns_dict():
+    d = {"a": 1}
+    assert _get_nested(d, "") is d
+
+
+def test_get_nested_non_dict_intermediate():
+    # "name" is a string, not a dict — navigating further returns default.
+    d = {"name": "Test"}
+    assert _get_nested(d, "name.sub", default="x") == "x"
+
+
+def test_get_nested_list_index_out_of_bounds(config_path):
+    init_config(config_path)
+    assert get_config("cameras.devices[99]", default="missing") == "missing"
+
+
+def test_get_nested_list_on_non_list():
+    # Index accessor on a non-list value returns default.
+    d = {"a": {"b": "not-a-list"}}
+    assert _get_nested(d, "a.b[0]", default="nope") == "nope"
+
+
+# --- _set_nested ---
+
+
+def test_set_nested_creates_intermediate_dicts():
+    d: dict = {}
+    _set_nested(d, ["new", "deeply", "nested"], "value")
+    assert d == {"new": {"deeply": {"nested": "value"}}}
+
+
+def test_set_config_creates_new_nested_key(config_path):
+    init_config(config_path)
+    set_config("brand.new.key", "hello")
+    assert get_config("brand.new.key") == "hello"
+
+
+# --- auto-init behaviour ---
+
+
+def test_get_config_auto_inits_when_empty(config_path, monkeypatch):
+    """get_config should call init_config() automatically when the store is empty."""
+    monkeypatch.setattr(_store_mod, "_CONFIG", {})
+    monkeypatch.setattr(_store_mod, "_CONFIG_FILE", config_path)
+    result = get_config("name")
+    assert result == "Testing PANOPTES Unit"
+
+
+def test_set_config_auto_inits_when_empty(config_path, monkeypatch):
+    """set_config should call init_config() automatically when the store is empty."""
+    monkeypatch.setattr(_store_mod, "_CONFIG", {})
+    monkeypatch.setattr(_store_mod, "_CONFIG_FILE", config_path)
+    set_config("name", "Auto Init Test")
+    assert get_config("name") == "Auto Init Test"

--- a/tests/config/test_config_server.py
+++ b/tests/config/test_config_server.py
@@ -44,7 +44,7 @@ def test_get_config_default(config_path):
 def test_reload_config_restores_value(config_path):
     init_config(config_path)
     original = get_config("location.horizon")
-    set_config("location.horizon", 99 * u.degree)
+    set_config("location.horizon", 99 * u.degree, persist=False)
     assert get_config("location.horizon") == 99 * u.degree
 
     reload_config()
@@ -125,3 +125,30 @@ def test_set_config_auto_inits_when_empty(config_path, monkeypatch):
     monkeypatch.setattr(_store_mod, "_CONFIG_FILE", config_path)
     set_config("name", "Auto Init Test")
     assert get_config("name") == "Auto Init Test"
+
+
+# --- persist behaviour ---
+
+
+def test_set_config_persists_to_file_by_default(config_path):
+    """set_config should write to disk when persist=True (the default)."""
+    init_config(config_path)
+
+    set_config("name", "Persisted Name")
+
+    # Reload from disk to confirm the write happened.
+    reload_config()
+    assert get_config("name") == "Persisted Name"
+
+
+def test_set_config_no_persist_skips_file(config_path):
+    """set_config with persist=False should NOT write to disk."""
+    init_config(config_path)
+
+    original_name = get_config("name")
+    set_config("name", "In Memory Only", persist=False)
+    assert get_config("name") == "In Memory Only"
+
+    # Reload from disk — original value should be restored.
+    reload_config()
+    assert get_config("name") == original_name


### PR DESCRIPTION
## Summary

Adds a new file-based in-memory config store (`panoptes.utils.config.store`) as the standard way to load and access PANOPTES configuration — no server process required. The existing HTTP config server and client are deprecated in favour of this approach.

## Changes

### Added
- `panoptes.utils.config.store` — `init_config`, `reload_config`, `get_config`, `set_config`. Config is loaded directly from a YAML file into a process-level dict.

### Changed
- `panoptes-utils config get` / `config set` now read/write via the store. `--host`/`--port` removed; use `--config-file` (or `$PANOPTES_CONFIG_FILE`) instead.
- Test suite initialises the store from `tests/testing.yaml` directly — no HTTP server started during tests.
- Removed the startup import of `server` from `cli/main.py`.

### Deprecated
- `panoptes.utils.config.client` — emits `DeprecationWarning` on import.
- `panoptes.utils.config.server` — emits `DeprecationWarning` on import.
- `panoptes-utils config run` / `config stop` — emit `DeprecationWarning` at runtime.

Full removal is tracked in #366.